### PR TITLE
Enhance passiveRecon test suite for better debugging

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module passive-rec
 
 go 1.22
+
+require github.com/google/go-cmp v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -1,0 +1,85 @@
+package pipeline
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestSinkClassification(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	sink, err := NewSink(dir)
+	if err != nil {
+		t.Fatalf("NewSink: %v", err)
+	}
+
+	sink.Start(1)
+
+	inputs := []string{
+		"  example.com  ",
+		"https://app.example.com/login",
+		"http://example.com/about",
+		"meta: run started",
+		"sub.example.com/path",
+		"www.example.com",
+		"meta: run started",
+		"alt1.example.com,alt2.example.com",
+		"alt2.example.com\nalt3.example.com",
+		"   ",
+	}
+
+	for _, line := range inputs {
+		sink.In() <- line
+	}
+
+	if err := sink.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	domains := readLines(t, filepath.Join(dir, "domains.passive"))
+	wantDomains := []string{"example.com"}
+	if diff := cmp.Diff(wantDomains, domains); diff != "" {
+		t.Fatalf("unexpected domains (-want +got):\n%s", diff)
+	}
+
+	routes := readLines(t, filepath.Join(dir, "routes.passive"))
+	wantRoutes := []string{
+		"https://app.example.com/login",
+		"http://example.com/about",
+		"http://sub.example.com/path",
+	}
+	if diff := cmp.Diff(wantRoutes, routes); diff != "" {
+		t.Fatalf("unexpected routes (-want +got):\n%s", diff)
+	}
+
+	certs := readLines(t, filepath.Join(dir, "certs.passive"))
+	wantCerts := []string{"alt1.example.com", "alt2.example.com", "alt3.example.com"}
+	if diff := cmp.Diff(wantCerts, certs); diff != "" {
+		t.Fatalf("unexpected certs (-want +got):\n%s", diff)
+	}
+
+	meta := readLines(t, filepath.Join(dir, "meta.passive"))
+	wantMeta := []string{"run started"}
+	if diff := cmp.Diff(wantMeta, meta); diff != "" {
+		t.Fatalf("unexpected meta (-want +got):\n%s", diff)
+	}
+}
+
+func readLines(t *testing.T, path string) []string {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%q): %v", path, err)
+	}
+	contents := strings.TrimSpace(string(data))
+	if contents == "" {
+		return nil
+	}
+	return strings.Split(contents, "\n")
+}


### PR DESCRIPTION
## Summary
- refactor writer package tests to use subtests, helper utilities, and detailed diffs for easier diagnosis
- add coverage for URL normalization and pipeline sink classification to surface issues earlier
- add go-cmp as a test dependency shared by the new assertions

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68dab99435c883298c17356c5d78c8c5