### PR TITLE
Improve logging facilities

### DIFF
--- a/cmd/passive-rec/main.go
+++ b/cmd/passive-rec/main.go
@@ -14,7 +14,7 @@ func main() {
 	cfg := config.ParseFlags()
 
 	logx.SetVerbosity(cfg.Verbosity)
-	logx.V(1, "Iniciando passive-rec target=%s outdir=%s tools=%v workers=%d active=%v",
+	logx.Infof("Iniciando passive-rec target=%s outdir=%s tools=%v workers=%d active=%v",
 		cfg.Target, cfg.OutDir, cfg.Tools, cfg.Workers, cfg.Active)
 
 	if cfg.Target == "" {
@@ -23,8 +23,8 @@ func main() {
 		os.Exit(1)
 	}
 	if err := app.Run(cfg); err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		logx.Errorf("%v", err)
 		os.Exit(1)
 	}
-	logx.V(1, "Listo. Archivos .passive creados en: %s", cfg.OutDir)
+	logx.Infof("Listo. Archivos .passive creados en: %s", cfg.OutDir)
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -71,7 +71,7 @@ func Run(cfg *config.Config) error {
 	}
 
 	wg.Wait()
-	logx.V(1, "modo active=%v; terminado", cfg.Active)
+	logx.Infof("modo active=%v; terminado", cfg.Active)
 	return nil
 }
 
@@ -88,7 +88,7 @@ func (w *runnerWaitGroup) Go(fn func() error) {
 func (w *runnerWaitGroup) Wait() {
 	for _, ch := range w.ch {
 		if err := <-ch; err != nil {
-			logx.V(1, "source error: %v", err)
+			logx.Warnf("source error: %v", err)
 		}
 	}
 }

--- a/internal/logx/logx.go
+++ b/internal/logx/logx.go
@@ -2,25 +2,133 @@ package logx
 
 import (
 	"fmt"
+	"io"
 	"os"
+	"sync"
 	"time"
 )
 
-var verbosity = 0
+type Level int
 
-func SetVerbosity(v int) { verbosity = v }
+const (
+	LevelError Level = iota
+	LevelWarn
+	LevelInfo
+	LevelDebug
+)
 
-// V(level>=1 info, >=2 debug)
-func V(level int, format string, a ...interface{}) {
-	if verbosity >= level {
-		prefix := "[INFO]"
-		if level >= 2 {
-			prefix = "[DEBUG]"
-		}
-		fmt.Fprintf(os.Stderr, "%s %s %s\n",
-			time.Now().Format(time.RFC3339),
-			prefix,
-			fmt.Sprintf(format, a...),
-		)
+type levelInfo struct {
+	label string
+	color string
+}
+
+var (
+	mu           sync.RWMutex
+	verbosity              = 0
+	output       io.Writer = os.Stderr
+	colorEnabled           = true
+	levels                 = map[Level]levelInfo{
+		LevelError: {label: "[ERROR]", color: "\x1b[31m"},
+		LevelWarn:  {label: "[WARN]", color: "\x1b[33m"},
+		LevelInfo:  {label: "[INFO]", color: "\x1b[36m"},
+		LevelDebug: {label: "[DEBUG]", color: "\x1b[35m"},
 	}
+)
+
+// SetVerbosity configura el nivel máximo de detalle a imprimir (0=errores, 1=info, 2=debug).
+func SetVerbosity(v int) {
+	mu.Lock()
+	verbosity = v
+	mu.Unlock()
+}
+
+// SetOutput permite redirigir la salida del log. Si w es nil se usa stderr.
+func SetOutput(w io.Writer) {
+	mu.Lock()
+	if w == nil {
+		output = os.Stderr
+	} else {
+		output = w
+	}
+	mu.Unlock()
+}
+
+// EnableColors permite activar o desactivar colores ANSI en la salida.
+func EnableColors(enabled bool) {
+	mu.Lock()
+	colorEnabled = enabled
+	mu.Unlock()
+}
+
+// Errorf imprime siempre, independiente de la verbosidad configurada.
+func Errorf(format string, a ...interface{}) { logf(LevelError, format, a...) }
+
+// Warnf respeta verbosidad >=0 (por defecto visible salvo modo silencioso estricto).
+func Warnf(format string, a ...interface{}) { logf(LevelWarn, format, a...) }
+
+// Infof requiere verbosidad >=1.
+func Infof(format string, a ...interface{}) { logf(LevelInfo, format, a...) }
+
+// Debugf requiere verbosidad >=2.
+func Debugf(format string, a ...interface{}) { logf(LevelDebug, format, a...) }
+
+// V mantiene compatibilidad con la API anterior.
+// level>=1 equivale a Info, >=2 a Debug. Valores <=0 se consideran advertencias.
+func V(level int, format string, a ...interface{}) {
+	switch {
+	case level <= 0:
+		Warnf(format, a...)
+	case level == 1:
+		Infof(format, a...)
+	default:
+		Debugf(format, a...)
+	}
+}
+
+func logf(level Level, format string, a ...interface{}) {
+	if !shouldLog(level) {
+		return
+	}
+	msg := fmt.Sprintf(format, a...)
+	stamp := time.Now().Format(time.RFC3339)
+	label := formatLabel(level)
+
+	mu.RLock()
+	out := output
+	mu.RUnlock()
+
+	fmt.Fprintf(out, "%s %s %s\n", stamp, label, msg)
+}
+
+func shouldLog(level Level) bool {
+	mu.RLock()
+	v := verbosity
+	mu.RUnlock()
+
+	switch level {
+	case LevelError:
+		return true
+	case LevelWarn:
+		return v >= 0
+	case LevelInfo:
+		return v >= 1
+	case LevelDebug:
+		return v >= 2
+	default:
+		return false
+	}
+}
+
+func formatLabel(level Level) string {
+	info, ok := levels[level]
+	if !ok {
+		return "[LOG]"
+	}
+	mu.RLock()
+	useColors := colorEnabled
+	mu.RUnlock()
+	if !useColors {
+		return info.label
+	}
+	return fmt.Sprintf("%s%s\x1b[0m", info.color, info.label)
 }

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -16,18 +16,18 @@ func HasBin(name string) bool {
 }
 
 func RunCommand(ctx context.Context, name string, args []string, out chan<- string) error {
-	logx.V(2, "run: %s %s", name, strings.Join(args, " "))
+	logx.Debugf("run: %s %s", name, strings.Join(args, " "))
 	cmd := exec.CommandContext(ctx, name, args...)
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
-		logx.V(1, "stdout pipe %s: %v", name, err)
+		logx.Errorf("stdout pipe %s: %v", name, err)
 		return err
 	}
 	stderr, _ := cmd.StderrPipe()
 
 	if err := cmd.Start(); err != nil {
-		logx.V(1, "start %s: %v", name, err)
+		logx.Errorf("start %s: %v", name, err)
 		return err
 	}
 
@@ -35,7 +35,7 @@ func RunCommand(ctx context.Context, name string, args []string, out chan<- stri
 	go func() {
 		s := bufio.NewScanner(stderr)
 		for s.Scan() {
-			logx.V(2, "%s stderr: %s", name, s.Text())
+			logx.Debugf("%s stderr: %s", name, s.Text())
 		}
 	}()
 
@@ -43,21 +43,21 @@ func RunCommand(ctx context.Context, name string, args []string, out chan<- stri
 	for s.Scan() {
 		select {
 		case <-ctx.Done():
-			logx.V(1, "ctx cancel %s", name)
+			logx.Warnf("ctx cancel %s", name)
 			return ctx.Err()
 		default:
 			out <- s.Text()
 		}
 	}
 	if err := s.Err(); err != nil {
-		logx.V(1, "scan %s: %v", name, err)
+		logx.Errorf("scan %s: %v", name, err)
 		return err
 	}
 	if err := cmd.Wait(); err != nil {
-		logx.V(1, "wait %s: %v", name, err)
+		logx.Errorf("wait %s: %v", name, err)
 		return err
 	}
-	logx.V(2, "done: %s", name)
+	logx.Debugf("done: %s", name)
 	return nil
 }
 

--- a/internal/sources/crtsh.go
+++ b/internal/sources/crtsh.go
@@ -12,7 +12,7 @@ import (
 )
 
 func CRTSH(ctx context.Context, domain string, out chan<- string) error {
-	logx.V(2, "crtsh query %s", domain)
+	logx.Debugf("crtsh query %s", domain)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
 		"https://crt.sh/?q=%25."+domain+"&output=json", nil)
@@ -23,12 +23,12 @@ func CRTSH(ctx context.Context, domain string, out chan<- string) error {
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		logx.V(1, "crtsh http: %v", err)
+		logx.Errorf("crtsh http: %v", err)
 		return err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
-		logx.V(1, "crtsh non-200: %d", resp.StatusCode)
+		logx.Errorf("crtsh non-200: %d", resp.StatusCode)
 		return errors.New("crt.sh non-200")
 	}
 	body, err := io.ReadAll(resp.Body)
@@ -37,7 +37,7 @@ func CRTSH(ctx context.Context, domain string, out chan<- string) error {
 	}
 	var arr []map[string]any
 	if err := json.Unmarshal(body, &arr); err != nil {
-		logx.V(1, "crtsh json: %v", err)
+		logx.Errorf("crtsh json: %v", err)
 		return err
 	}
 	for _, o := range arr {


### PR DESCRIPTION
## Summary
- replace the simple verbosity helper with a leveled logger that supports color output, configurable sinks, and dedicated helpers
- migrate call sites to the new Info/Warn/Error helpers to improve clarity of emitted messages

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68dbf2e5a46083299f21f1ef0c69f981