### PR TITLE
Improve missing tool reporting and sink output

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -9,6 +10,7 @@ import (
 	"passive-rec/internal/config"
 	"passive-rec/internal/logx"
 	"passive-rec/internal/pipeline"
+	"passive-rec/internal/runner"
 	"passive-rec/internal/sources"
 )
 
@@ -88,6 +90,9 @@ func (w *runnerWaitGroup) Go(fn func() error) {
 func (w *runnerWaitGroup) Wait() {
 	for _, ch := range w.ch {
 		if err := <-ch; err != nil {
+			if errors.Is(err, runner.ErrMissingBinary) {
+				continue
+			}
 			logx.Warnf("source error: %v", err)
 		}
 	}

--- a/internal/app/progress.go
+++ b/internal/app/progress.go
@@ -1,10 +1,14 @@
 package app
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
 	"sync"
+
+	"passive-rec/internal/runner"
 )
 
 type progressBar struct {
@@ -42,7 +46,14 @@ func (p *progressBar) Wrap(tool string, fn func() error) func() error {
 		err := fn()
 		status := "ok"
 		if err != nil {
-			status = "error"
+			switch {
+			case errors.Is(err, runner.ErrMissingBinary):
+				status = "faltante"
+			case errors.Is(err, context.DeadlineExceeded):
+				status = "timeout"
+			default:
+				status = "error"
+			}
 		}
 		p.StepDone(tool, status)
 		return err

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -9,40 +9,59 @@ import (
 )
 
 type Sink struct {
-	Domains *out.Writer
-	Routes  *out.Writer
-	Certs   *out.Writer
-	Meta    *out.Writer
-	wg      sync.WaitGroup
-	lines   chan string
+	Domains     *out.Writer
+	Routes      *out.Writer
+	Certs       *out.Writer
+	Meta        *out.Writer
+	wg          sync.WaitGroup
+	lines       chan string
+	seenMu      sync.Mutex
+	seenDomains map[string]struct{}
+	seenRoutes  map[string]struct{}
+	seenCerts   map[string]struct{}
 }
 
 func NewSink(outdir string) (*Sink, error) {
 	d, err := out.New(outdir, "domains.passive")
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 	r, err := out.New(outdir, "routes.passive")
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 	c, err := out.New(outdir, "certs.passive")
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 	m, err := out.New(outdir, "meta.passive")
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 
 	s := &Sink{
 		Domains: d, Routes: r, Certs: c, Meta: m,
-		lines: make(chan string, 1024),
+		lines:       make(chan string, 1024),
+		seenDomains: make(map[string]struct{}),
+		seenRoutes:  make(map[string]struct{}),
+		seenCerts:   make(map[string]struct{}),
 	}
 	return s, nil
 }
 
 func (s *Sink) Start(workers int) {
-	if workers < 1 { workers = 1 }
+	if workers < 1 {
+		workers = 1
+	}
 	for i := 0; i < workers; i++ {
 		s.wg.Add(1)
 		go func() {
 			defer s.wg.Done()
 			for ln := range s.lines {
 				l := strings.TrimSpace(ln)
-				if l == "" { continue }
+				if l == "" {
+					continue
+				}
 
 				// meta: prefijo "meta: ..."
 				if strings.HasPrefix(l, "meta: ") {
@@ -50,8 +69,16 @@ func (s *Sink) Start(workers int) {
 					continue
 				}
 
+				if strings.Contains(l, "-->") || strings.Contains(l, " (") {
+					_ = s.Meta.WriteRaw(l)
+					continue
+				}
+
 				// Clasificación simple: URLs/rutas si contiene esquema o '/'
 				if strings.Contains(l, "http://") || strings.Contains(l, "https://") || strings.Contains(l, "/") {
+					if s.markSeen(s.seenRoutes, l) {
+						continue
+					}
 					_ = s.Routes.WriteURL(l)
 					continue
 				}
@@ -60,12 +87,24 @@ func (s *Sink) Start(workers int) {
 				if strings.Contains(l, ",") || strings.Contains(l, "\n") {
 					parts := strings.FieldsFunc(l, func(r rune) bool { return r == ',' || r == '\n' })
 					for _, p := range parts {
+						p = strings.TrimSpace(p)
+						if p == "" {
+							continue
+						}
+						key := strings.ToLower(p)
+						if s.markSeen(s.seenCerts, key) {
+							continue
+						}
 						_ = s.Certs.WriteRaw(p)
 					}
 					continue
 				}
 
 				// defecto: dominio
+				key := strings.ToLower(l)
+				if s.markSeen(s.seenDomains, key) {
+					continue
+				}
 				_ = s.Domains.WriteDomain(l)
 			}
 		}()
@@ -86,3 +125,13 @@ func (s *Sink) Close() error {
 
 // Helper para ejecutar una fuente con contexto y volcar al sink
 type SourceFunc func(ctx context.Context, target string, out chan<- string) error
+
+func (s *Sink) markSeen(seen map[string]struct{}, key string) bool {
+	s.seenMu.Lock()
+	defer s.seenMu.Unlock()
+	if _, ok := seen[key]; ok {
+		return true
+	}
+	seen[key] = struct{}{}
+	return false
+}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -3,12 +3,15 @@ package runner
 import (
 	"bufio"
 	"context"
+	"errors"
 	"os/exec"
 	"strings"
 	"time"
 
 	"passive-rec/internal/logx"
 )
+
+var ErrMissingBinary = errors.New("missing binary")
 
 func HasBin(name string) bool {
 	_, err := exec.LookPath(name)
@@ -27,6 +30,9 @@ func RunCommand(ctx context.Context, name string, args []string, out chan<- stri
 	stderr, _ := cmd.StderrPipe()
 
 	if err := cmd.Start(); err != nil {
+		if errors.Is(err, exec.ErrNotFound) {
+			return ErrMissingBinary
+		}
 		logx.Errorf("start %s: %v", name, err)
 		return err
 	}

--- a/internal/sources/amass.go
+++ b/internal/sources/amass.go
@@ -9,7 +9,7 @@ import (
 func Amass(ctx context.Context, target string, out chan<- string) error {
 	if !runner.HasBin("amass") {
 		out <- "meta: amass not found in PATH"
-		return nil
+		return runner.ErrMissingBinary
 	}
 	return runner.RunCommand(ctx, "amass", []string{"enum", "-passive", "-d", target}, out)
 }

--- a/internal/sources/assetfinder.go
+++ b/internal/sources/assetfinder.go
@@ -9,7 +9,7 @@ import (
 func Assetfinder(ctx context.Context, target string, out chan<- string) error {
 	if !runner.HasBin("assetfinder") {
 		out <- "meta: assetfinder not found in PATH"
-		return nil
+		return runner.ErrMissingBinary
 	}
 	return runner.RunCommand(ctx, "assetfinder", []string{"--subs-only", target}, out)
 }

--- a/internal/sources/gau.go
+++ b/internal/sources/gau.go
@@ -10,7 +10,7 @@ import (
 func GAU(ctx context.Context, target string, out chan<- string) error {
 	if !runner.HasBin("gau") {
 		out <- "meta: gau not found in PATH"
-		return nil
+		return runner.ErrMissingBinary
 	}
 	return runner.RunCommand(ctx, "sh", []string{"-c", fmt.Sprintf("echo %s | gau", target)}, out)
 }

--- a/internal/sources/httpx.go
+++ b/internal/sources/httpx.go
@@ -11,7 +11,7 @@ import (
 func HTTPX(ctx context.Context, domainsFile, outdir string, out chan<- string) error {
 	if !runner.HasBin("httpx") {
 		out <- "meta: httpx not found in PATH"
-		return nil
+		return runner.ErrMissingBinary
 	}
 	return runner.RunCommand(ctx, "sh",
 		[]string{"-c", fmt.Sprintf("cat %s | httpx -status -title -silent",

--- a/internal/sources/subfinder.go
+++ b/internal/sources/subfinder.go
@@ -9,7 +9,7 @@ import (
 func Subfinder(ctx context.Context, target string, out chan<- string) error {
 	if !runner.HasBin("subfinder") {
 		out <- "meta: subfinder not found in PATH"
-		return nil
+		return runner.ErrMissingBinary
 	}
 	return runner.RunCommand(ctx, "subfinder", []string{"-d", target, "-silent"}, out)
 }

--- a/internal/sources/wayback.go
+++ b/internal/sources/wayback.go
@@ -10,7 +10,7 @@ import (
 func Wayback(ctx context.Context, target string, out chan<- string) error {
 	if !runner.HasBin("waybackurls") {
 		out <- "meta: waybackurls not found in PATH"
-		return nil
+		return runner.ErrMissingBinary
 	}
 	// echo target | waybackurls
 	return runner.RunCommand(ctx, "sh", []string{"-c", fmt.Sprintf("echo %s | waybackurls", target)}, out)


### PR DESCRIPTION
## Summary
- add explicit missing-binary handling so the progress bar reflects skipped tools and logging ignores benign skips
- deduplicate sink writes and divert annotated lines to the meta output for cleaner domain/route files
- surface missing dependency metadata from individual sources using a shared sentinel error

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68dbf52b05a0832981348aedaca0dff5