### PR TITLE
Run gau, waybackurls, and httpx without shell wrappers

### DIFF
--- a/internal/sources/gau.go
+++ b/internal/sources/gau.go
@@ -2,7 +2,6 @@ package sources
 
 import (
 	"context"
-	"fmt"
 
 	"passive-rec/internal/runner"
 )
@@ -12,5 +11,5 @@ func GAU(ctx context.Context, target string, out chan<- string) error {
 		out <- "meta: gau not found in PATH"
 		return runner.ErrMissingBinary
 	}
-	return runner.RunCommand(ctx, "sh", []string{"-c", fmt.Sprintf("echo %s | gau", target)}, out)
+	return runner.RunCommand(ctx, "gau", []string{target}, out)
 }

--- a/internal/sources/httpx.go
+++ b/internal/sources/httpx.go
@@ -2,7 +2,6 @@ package sources
 
 import (
 	"context"
-	"fmt"
 	"path/filepath"
 
 	"passive-rec/internal/runner"
@@ -13,9 +12,11 @@ func HTTPX(ctx context.Context, domainsFile, outdir string, out chan<- string) e
 		out <- "meta: httpx not found in PATH"
 		return runner.ErrMissingBinary
 	}
-	return runner.RunCommand(ctx, "sh",
-		[]string{"-c", fmt.Sprintf("cat %s | httpx -status -title -silent",
-			filepath.Join(outdir, domainsFile))},
-		out,
-	)
+	return runner.RunCommand(ctx, "httpx", []string{
+		"-status",
+		"-title",
+		"-silent",
+		"-l",
+		filepath.Join(outdir, domainsFile),
+	}, out)
 }

--- a/internal/sources/wayback.go
+++ b/internal/sources/wayback.go
@@ -2,7 +2,6 @@ package sources
 
 import (
 	"context"
-	"fmt"
 
 	"passive-rec/internal/runner"
 )
@@ -12,6 +11,5 @@ func Wayback(ctx context.Context, target string, out chan<- string) error {
 		out <- "meta: waybackurls not found in PATH"
 		return runner.ErrMissingBinary
 	}
-	// echo target | waybackurls
-	return runner.RunCommand(ctx, "sh", []string{"-c", fmt.Sprintf("echo %s | waybackurls", target)}, out)
+	return runner.RunCommand(ctx, "waybackurls", []string{target}, out)
 }


### PR DESCRIPTION
## Summary
- call gau and waybackurls directly with the target argument instead of shell pipelines
- run httpx directly with -l pointing to the generated domains file while preserving existing flags

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68dbff164a8483298ccbf6b58ed4394d