### PR TITLE
Add progress bar tests and fix GAU binary usage

### DIFF
--- a/internal/app/progress_test.go
+++ b/internal/app/progress_test.go
@@ -1,0 +1,52 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"passive-rec/internal/runner"
+)
+
+func TestProgressBarWrapAndMissingTools(t *testing.T) {
+	var buf bytes.Buffer
+	pb := newProgressBar(5, &buf)
+
+	if pb == nil {
+		t.Fatal("expected progress bar instance")
+	}
+
+	if err := pb.Wrap("ToolOk", func() error { return nil })(); err != nil {
+		t.Fatalf("wrap ok returned error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "ToolOk (ok)") {
+		t.Fatalf("expected ok status in buffer, got: %q", buf.String())
+	}
+
+	if err := pb.Wrap("ToolMissing", func() error { return runner.ErrMissingBinary })(); err == nil {
+		t.Fatalf("expected missing binary error")
+	}
+	if !strings.Contains(buf.String(), "ToolMissing (faltante)") {
+		t.Fatalf("expected missing status in buffer, got: %q", buf.String())
+	}
+
+	if err := pb.Wrap("ToolTimeout", func() error { return context.DeadlineExceeded })(); err == nil {
+		t.Fatalf("expected deadline exceeded error")
+	}
+	if !strings.Contains(buf.String(), "ToolTimeout (timeout)") {
+		t.Fatalf("expected timeout status in buffer, got: %q", buf.String())
+	}
+
+	pb.StepDone("toolmissing", "faltante")
+	pb.StepDone("TOOLMISSING", "faltante")
+
+	missing := pb.MissingTools()
+	if len(missing) != 1 || missing[0] != "ToolMissing" {
+		t.Fatalf("expected deduplicated missing tools, got: %#v", missing)
+	}
+
+	if !strings.HasSuffix(buf.String(), "\n") {
+		t.Fatalf("expected buffer to end with newline after completing steps, got: %q", buf.String())
+	}
+}

--- a/internal/sources/gau.go
+++ b/internal/sources/gau.go
@@ -12,6 +12,6 @@ func GAU(ctx context.Context, target string, out chan<- string) error {
 		out <- "meta: gau/getallurls not found in PATH"
 		return runner.ErrMissingBinary
 	}
-	return runner.RunCommand(ctx, "gau", []string{target}, out)
+    return runner.RunCommand(ctx, bin, []string{target}, out)
 
 }


### PR DESCRIPTION
## Summary
- add coverage for progress bar wrap status handling and missing tool deduplication
- fix the GAU source to invoke the discovered binary path when running

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68dc02fa458c83299b513c81fd30352a