### PR TITLE
Update httpx flags to match latest CLI

### DIFF
--- a/internal/sources/httpx.go
+++ b/internal/sources/httpx.go
@@ -13,7 +13,7 @@ func HTTPX(ctx context.Context, domainsFile, outdir string, out chan<- string) e
 		return runner.ErrMissingBinary
 	}
 	return runner.RunCommand(ctx, "httpx", []string{
-		"-status",
+		"-sc",
 		"-title",
 		"-silent",
 		"-l",


### PR DESCRIPTION
## Summary
- update the httpx source to use the -sc flag for status codes now required by the latest CLI

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68dc0407549c832985067f9f4b3413bc