### PR TITLE
Ensure HTTPX runs after sink flush for complete domain set

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -80,6 +80,7 @@ func Run(cfg *config.Config) error {
 	}
 
 	wg.Wait()
+	sink.Flush()
 	for _, task := range deferreds {
 		if err := task(); err != nil {
 			if errors.Is(err, runner.ErrMissingBinary) {


### PR DESCRIPTION
## Summary
- add synchronization to the pipeline sink to track in-flight items and expose a Flush method
- wait for the sink to flush before executing deferred active tools so httpx processes the full domain list
- cover the new flush behavior with a unit test

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68dc04d766788329927fe5743c77b28b