### PR TITLE
Ensure passive-rec selects ProjectDiscovery httpx binary

### DIFF
--- a/internal/sources/httpx.go
+++ b/internal/sources/httpx.go
@@ -8,11 +8,12 @@ import (
 )
 
 func HTTPX(ctx context.Context, domainsFile, outdir string, out chan<- string) error {
-	if !runner.HasBin("httpx") {
+	bin, err := runner.HTTPXBin()
+	if err != nil {
 		out <- "meta: httpx not found in PATH"
-		return runner.ErrMissingBinary
+		return err
 	}
-	return runner.RunCommand(ctx, "httpx", []string{
+	return runner.RunCommand(ctx, bin, []string{
 		"-sc",
 		"-title",
 		"-silent",


### PR DESCRIPTION
## Summary
- add a runner helper that selects the ProjectDiscovery httpx binary by inspecting command output
- use the helper in the httpx source so the tool no longer invokes the incompatible Python CLI

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68dc05e2c190832993ec66c72d0ea041