### PR TITLE
Run httpx against domain and route lists

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -66,8 +66,8 @@ func Run(cfg *config.Config) error {
 		case "httpx":
 			if cfg.Active {
 				deferreds = append(deferreds, bar.Wrap(toolName, runWithTimeout(ctx, cfg.TimeoutS, func(c context.Context) error {
-					// leer de domains.passive generado
-					return sources.HTTPX(c, "domains.passive", cfg.OutDir, sink.In())
+					// leer de domains/routes.passive generado
+					return sources.HTTPX(c, []string{"domains.passive", "routes.passive"}, cfg.OutDir, sink.In())
 				})))
 			} else {
 				sink.In() <- "meta: httpx skipped (requires --active)"

--- a/internal/sources/httpx.go
+++ b/internal/sources/httpx.go
@@ -2,22 +2,54 @@ package sources
 
 import (
 	"context"
+	"errors"
+	"os"
 	"path/filepath"
+	"strings"
 
 	"passive-rec/internal/runner"
 )
 
-func HTTPX(ctx context.Context, domainsFile, outdir string, out chan<- string) error {
-	bin, err := runner.HTTPXBin()
+var (
+	httpxBinFinder = runner.HTTPXBin
+	httpxRunCmd    = runner.RunCommand
+)
+
+func HTTPX(ctx context.Context, listFiles []string, outdir string, out chan<- string) error {
+	bin, err := httpxBinFinder()
 	if err != nil {
 		out <- "meta: httpx not found in PATH"
 		return err
 	}
-	return runner.RunCommand(ctx, bin, []string{
-		"-sc",
-		"-title",
-		"-silent",
-		"-l",
-		filepath.Join(outdir, domainsFile),
-	}, out)
+
+	for _, list := range listFiles {
+		list = strings.TrimSpace(list)
+		if list == "" {
+			continue
+		}
+
+		inputPath := filepath.Join(outdir, list)
+		if stat, err := os.Stat(inputPath); err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				out <- "meta: httpx skipped missing input " + list
+				continue
+			}
+			return err
+		} else if stat.Size() == 0 {
+			// Avoid spawning httpx with empty inputs; just skip silently.
+			continue
+		}
+
+		if err := httpxRunCmd(ctx, bin, []string{
+			"-sc",
+			"-title",
+			"-silent",
+			"-l",
+			inputPath,
+		}, out); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/internal/sources/httpx_test.go
+++ b/internal/sources/httpx_test.go
@@ -1,0 +1,60 @@
+package sources
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+func TestHTTPXIteratesAllLists(t *testing.T) {
+	tmp := t.TempDir()
+	mustWrite := func(name string) {
+		if err := os.WriteFile(filepath.Join(tmp, name), []byte("example.com"), 0644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	mustWrite("domains.passive")
+	mustWrite("routes.passive")
+
+	originalBinFinder := httpxBinFinder
+	originalRunCmd := httpxRunCmd
+	t.Cleanup(func() {
+		httpxBinFinder = originalBinFinder
+		httpxRunCmd = originalRunCmd
+	})
+
+	httpxBinFinder = func() (string, error) { return "httpx", nil }
+
+	var mu sync.Mutex
+	var got [][]string
+	httpxRunCmd = func(ctx context.Context, name string, args []string, out chan<- string) error {
+		mu.Lock()
+		defer mu.Unlock()
+		cp := append([]string{}, args...)
+		got = append(got, cp)
+		return nil
+	}
+
+	if err := HTTPX(context.Background(), []string{"domains.passive", "routes.passive"}, tmp, make(chan string, 10)); err != nil {
+		t.Fatalf("HTTPX returned error: %v", err)
+	}
+
+	if len(got) != 2 {
+		t.Fatalf("expected 2 calls to httpxRunCmd, got %d", len(got))
+	}
+
+	wantPaths := []string{
+		filepath.Join(tmp, "domains.passive"),
+		filepath.Join(tmp, "routes.passive"),
+	}
+	for i, args := range got {
+		if len(args) != 5 {
+			t.Fatalf("call %d: unexpected arg count %d", i, len(args))
+		}
+		if args[4] != wantPaths[i] {
+			t.Fatalf("call %d: expected path %s, got %s", i, wantPaths[i], args[4])
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- update the httpx source runner so it sequentially processes both domain and route lists when available
- skip spawning httpx for missing or empty inputs while keeping meta feedback for missing files
- add a unit test that verifies both lists are forwarded to the httpx runner and adjust the app wiring accordingly

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68dc0fcc43248329bdd246005129b023