### PR TITLE
Ensure runWithTimeout applies default timeout and add test

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"time"
 
 	"passive-rec/internal/config"
 	"passive-rec/internal/logx"
@@ -119,7 +118,7 @@ func (w *runnerWaitGroup) Wait() {
 
 func runWithTimeout(parent context.Context, seconds int, fn func(context.Context) error) func() error {
 	return func() error {
-		ctx, cancel := context.WithTimeout(parent, time.Duration(seconds)*time.Second)
+		ctx, cancel := runner.WithTimeout(parent, seconds)
 		defer cancel()
 		return fn(ctx)
 	}

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1,0 +1,38 @@
+package app
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestRunWithTimeoutDefault(t *testing.T) {
+	parent := context.Background()
+	invoked := false
+
+	err := runWithTimeout(parent, 0, func(ctx context.Context) error {
+		invoked = true
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(10 * time.Millisecond):
+		}
+
+		deadline, ok := ctx.Deadline()
+		if !ok {
+			t.Fatalf("expected deadline to be set when timeout is zero")
+		}
+		if remaining := time.Until(deadline); remaining < time.Second {
+			t.Fatalf("expected generous timeout, got remaining=%s", remaining)
+		}
+		return nil
+	})()
+
+	if err != nil {
+		t.Fatalf("runWithTimeout returned error: %v", err)
+	}
+	if !invoked {
+		t.Fatalf("expected function to be invoked")
+	}
+}


### PR DESCRIPTION
## Summary
- delegate timeout handling in `runWithTimeout` to `runner.WithTimeout` so zero-second values pick up the default
- add a unit test that confirms a zero timeout does not cancel work immediately

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68dd399f8c0c8329b333b7b819bda75b