### PR TITLE
Add Censys certificate source

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,17 @@ go run ./cmd/install-deps
 ```
 
 The command reads `requirements.txt`, checks if each binary is already available on your `PATH`, and uses `go install` to fetch any missing tools. The installation succeeds only if you have Go installed locally and network access to download the modules. Tools are installed into your `GOBIN` directory (or `$GOPATH/bin` if `GOBIN` is not set), so make sure that directory is exported in your `PATH`.
+
+## Censys certificates integration
+
+The `censys` source consumes the [Censys Search API](https://search.censys.io/api) to enumerate hosts from the certificate corpus. You must supply your account credentials through the new flags or environment variables:
+
+```bash
+passive-rec --tools censys --censys-api-id "$CENSYS_API_ID" --censys-api-secret "$CENSYS_API_SECRET"
+# or export them before running
+export CENSYS_API_ID=...
+export CENSYS_API_SECRET=...
+passive-rec --tools censys
+```
+
+Censys enforces per-account rate limits (for example, free accounts currently offer 250 Search credits per month and strict request throttling). Review the [official limits](https://support.censys.io/hc/en-us/articles/360059995051-Rate-Limits-and-Quotas) that apply to your plan and adjust your `--timeout` or tool selection accordingly to avoid hitting those quotas.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -63,6 +63,10 @@ func Run(cfg *config.Config) error {
 			wg.Go(bar.Wrap(toolName, runWithTimeout(ctx, cfg.TimeoutS, func(c context.Context) error {
 				return sources.CRTSH(c, cfg.Target, sink.In())
 			})))
+		case "censys":
+			wg.Go(bar.Wrap(toolName, runWithTimeout(ctx, cfg.TimeoutS, func(c context.Context) error {
+				return sources.Censys(c, cfg.Target, cfg.CensysAPIID, cfg.CensysAPISecret, sink.In())
+			})))
 		case "httpx":
 			if cfg.Active {
 				deferreds = append(deferreds, bar.Wrap(toolName, runWithTimeout(ctx, cfg.TimeoutS, func(c context.Context) error {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,17 +2,20 @@ package config
 
 import (
 	"flag"
+	"os"
 	"strings"
 )
 
 type Config struct {
-	Target    string
-	OutDir    string
-	Workers   int
-	Active    bool
-	Tools     []string
-	TimeoutS  int
-	Verbosity int
+	Target          string
+	OutDir          string
+	Workers         int
+	Active          bool
+	Tools           []string
+	TimeoutS        int
+	Verbosity       int
+	CensysAPIID     string
+	CensysAPISecret string
 }
 
 func ParseFlags() *Config {
@@ -23,6 +26,8 @@ func ParseFlags() *Config {
 	tools := flag.String("tools", "subfinder,assetfinder,amass,waybackurls,gau,crtsh,httpx", "Herramientas, CSV")
 	timeout := flag.Int("timeout", 120, "Timeout por herramienta (segundos)")
 	verbosity := flag.Int("v", 0, "Verbosity (0=silent,1=info,2=debug,3=trace)")
+	censysID := flag.String("censys-api-id", os.Getenv("CENSYS_API_ID"), "Censys API ID (o exporta CENSYS_API_ID)")
+	censysSecret := flag.String("censys-api-secret", os.Getenv("CENSYS_API_SECRET"), "Censys API secret (o exporta CENSYS_API_SECRET)")
 	flag.Parse()
 
 	list := []string{}
@@ -38,12 +43,14 @@ func ParseFlags() *Config {
 	}
 
 	return &Config{
-		Target:    *target,
-		OutDir:    *outdir,
-		Workers:   *workers,
-		Active:    *active,
-		Tools:     list,
-		TimeoutS:  *timeout,
-		Verbosity: *verbosity,
+		Target:          *target,
+		OutDir:          *outdir,
+		Workers:         *workers,
+		Active:          *active,
+		Tools:           list,
+		TimeoutS:        *timeout,
+		Verbosity:       *verbosity,
+		CensysAPIID:     strings.TrimSpace(*censysID),
+		CensysAPISecret: strings.TrimSpace(*censysSecret),
 	}
 }

--- a/internal/sources/censys_test.go
+++ b/internal/sources/censys_test.go
@@ -1,0 +1,99 @@
+package sources
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCensysPagination(t *testing.T) {
+	var serverURL string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		username, password, ok := r.BasicAuth()
+		if !ok || username != "id" || password != "secret" {
+			t.Fatalf("unexpected auth: %v %s/%s", ok, username, password)
+		}
+
+		switch r.URL.Query().Get("page") {
+		case "", "1":
+			if got := r.URL.Query().Get("q"); got != "parsed.names: example.com" {
+				t.Fatalf("unexpected query: %s", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{
+  "result": {
+    "hits": [
+      {
+        "name": "example.com",
+        "parsed": {
+          "subject": {"common_name": "example.com"},
+          "names": ["example.com", "www.example.com"]
+        }
+      }
+    ],
+    "links": {"next": "` + serverURL + `/api/v2/certificates/search?page=2"}
+  }
+}`))
+		case "2":
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{
+  "result": {
+    "hits": [
+      {
+        "name": "alt.example.com",
+        "parsed": {
+          "subject": {"common_name": "alt.example.com"},
+          "names": ["alt.example.com", "legacy.example.com"]
+        }
+      }
+    ],
+    "links": {"next": ""}
+  }
+}`))
+		default:
+			t.Fatalf("unexpected page: %s", r.URL.Query().Get("page"))
+		}
+	}))
+	defer srv.Close()
+
+	serverURL = srv.URL
+	oldURL := censysBaseURL
+	oldClient := censysHTTPClient
+	censysBaseURL = serverURL + "/api/v2/certificates/search"
+	censysHTTPClient = srv.Client()
+	defer func() {
+		censysBaseURL = oldURL
+		censysHTTPClient = oldClient
+	}()
+
+	out := make(chan string, 16)
+	if err := Censys(context.Background(), "example.com", "id", "secret", out); err != nil {
+		t.Fatalf("censys returned error: %v", err)
+	}
+
+	results := make(map[string]bool)
+	for len(out) > 0 {
+		results[<-out] = true
+	}
+
+	expected := []string{"example.com", "www.example.com", "alt.example.com", "legacy.example.com"}
+	for _, name := range expected {
+		if !results[name] {
+			t.Fatalf("missing result %s", name)
+		}
+	}
+	if len(results) != len(expected) {
+		t.Fatalf("unexpected number of results: %d", len(results))
+	}
+}
+
+func TestCensysMissingCredentials(t *testing.T) {
+	out := make(chan string, 1)
+	if err := Censys(context.Background(), "example.com", "", "", out); err == nil {
+		t.Fatal("expected error for missing credentials")
+	}
+	if len(out) != 0 {
+		t.Fatalf("unexpected output when credentials missing: %d", len(out))
+	}
+}


### PR DESCRIPTION
## Summary
- add configuration flags and environment fallbacks for Censys API credentials
- implement a Censys certificate source with pagination support and simulated API tests
- document credential setup and rate limits for the new source in the README

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68dd3a4eaeec8329be48066f8d8f46f6