### PR TITLE
Normalize URL handling before writing route outputs

### DIFF
--- a/internal/out/writer.go
+++ b/internal/out/writer.go
@@ -1,6 +1,7 @@
 package out
 
 import (
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -54,10 +55,28 @@ func normalizeURL(u string) string {
 	if u == "" {
 		return ""
 	}
-	if !(strings.HasPrefix(u, "http://") || strings.HasPrefix(u, "https://")) {
+
+	if !strings.Contains(u, "://") {
 		u = "http://" + u
 	}
-	return u
+
+	parsed, err := url.Parse(u)
+	if err != nil {
+		// Si la URL es inválida devolvemos la versión con esquema para evitar perder datos.
+		return u
+	}
+
+	parsed.Scheme = strings.ToLower(parsed.Scheme)
+	host := parsed.Hostname()
+	port := parsed.Port()
+	if host != "" {
+		parsed.Host = strings.ToLower(host)
+		if port != "" {
+			parsed.Host += ":" + port
+		}
+	}
+
+	return parsed.String()
 }
 
 func (w *Writer) WriteDomain(d string) error {

--- a/internal/out/writer_test.go
+++ b/internal/out/writer_test.go
@@ -36,11 +36,13 @@ func TestNormalizeURL(t *testing.T) {
 	t.Parallel()
 
 	cases := map[string]string{
-		"example.com":            "http://example.com",
-		"https://secure.example": "https://secure.example",
-		" http://foo.bar/baz ":   "http://foo.bar/baz",
-		"":                       "",
-		"//relative/path":        "http:////relative/path",
+		"example.com":             "http://example.com",
+		"https://secure.example":  "https://secure.example",
+		" http://foo.bar/baz ":    "http://foo.bar/baz",
+		"":                        "",
+		"//relative/path":         "http:////relative/path",
+		"HTTPS://Example.com":     "https://example.com",
+		"http://Example.com:8080": "http://example.com:8080",
 	}
 	for input, expected := range cases {
 		input, expected := input, expected


### PR DESCRIPTION
## Summary
- normalize URL inputs before writing routes to avoid duplicating entries when schemes or hosts use different casing
- leverage net/url parsing and extend tests to cover uppercase schemes and host/port preservation

## Testing
- go test ./...
- go test -race ./internal/out

------
https://chatgpt.com/codex/tasks/task_e_68dd3d3350548329b7f51f039bdb38dd