### PR TITLE
Ensure deferred HTTPX results are flushed before reporting

### DIFF
--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -2,8 +2,14 @@ package app
 
 import (
 	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
 	"testing"
 	"time"
+
+	"passive-rec/internal/config"
 )
 
 func TestRunWithTimeoutDefault(t *testing.T) {
@@ -34,5 +40,149 @@ func TestRunWithTimeoutDefault(t *testing.T) {
 	}
 	if !invoked {
 		t.Fatalf("expected function to be invoked")
+	}
+}
+
+func TestRunFlushesBeforeReportForDeferredSources(t *testing.T) {
+	originalSinkFactory := sinkFactory
+	originalHTTPX := sourceHTTPX
+	t.Cleanup(func() {
+		sinkFactory = originalSinkFactory
+		sourceHTTPX = originalHTTPX
+	})
+
+	dir := t.TempDir()
+
+	var (
+		mu      sync.Mutex
+		flushes int
+	)
+
+	sinkFactory = func(outdir string) (sink, error) {
+		ts, err := newTestSink(outdir)
+		if err != nil {
+			return nil, err
+		}
+		ts.onFlush = func() {
+			mu.Lock()
+			flushes++
+			mu.Unlock()
+		}
+		return ts, nil
+	}
+
+	sourceHTTPX = func(ctx context.Context, list []string, outdir string, out chan<- string) error {
+		out <- "http://deferred.test/path"
+		return nil
+	}
+
+	cfg := &config.Config{
+		Target:  "example.com",
+		OutDir:  dir,
+		Workers: 1,
+		Active:  true,
+		Tools:   []string{"httpx"},
+		Report:  true,
+	}
+
+	if err := Run(cfg); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	mu.Lock()
+	flushCount := flushes
+	mu.Unlock()
+	if flushCount < 2 {
+		t.Fatalf("expected at least two flushes, got %d", flushCount)
+	}
+
+	reportPath := filepath.Join(dir, "report.html")
+	reportData, err := os.ReadFile(reportPath)
+	if err != nil {
+		t.Fatalf("read report: %v", err)
+	}
+	if !strings.Contains(string(reportData), "deferred.test") {
+		t.Fatalf("expected report to include deferred source data, got:\n%s", string(reportData))
+	}
+}
+
+type testSink struct {
+	outdir  string
+	lines   chan string
+	pending []string
+	mu      sync.Mutex
+	onFlush func()
+}
+
+func newTestSink(outdir string) (*testSink, error) {
+	if err := os.MkdirAll(outdir, 0o755); err != nil {
+		return nil, err
+	}
+	return &testSink{
+		outdir: outdir,
+		lines:  make(chan string, 32),
+	}, nil
+}
+
+func (s *testSink) Start(workers int) {
+	// No background workers required for the test sink.
+}
+
+func (s *testSink) In() chan<- string {
+	return s.lines
+}
+
+func (s *testSink) Flush() {
+	s.mu.Lock()
+	for {
+		select {
+		case line, ok := <-s.lines:
+			if !ok {
+				break
+			}
+			s.pending = append(s.pending, line)
+		default:
+			goto drained
+		}
+	}
+drained:
+	pending := s.pending
+	s.pending = nil
+	onFlush := s.onFlush
+	s.mu.Unlock()
+
+	if onFlush != nil {
+		onFlush()
+	}
+
+	for _, line := range pending {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		targetFile := "domains.passive"
+		if strings.HasPrefix(trimmed, "meta: ") {
+			trimmed = strings.TrimSpace(strings.TrimPrefix(trimmed, "meta: "))
+			targetFile = "meta.passive"
+		} else if strings.Contains(trimmed, "://") || strings.Contains(trimmed, "/") {
+			targetFile = "routes.passive"
+		}
+		appendLine(filepath.Join(s.outdir, targetFile), trimmed)
+	}
+}
+
+func (s *testSink) Close() error {
+	close(s.lines)
+	return nil
+}
+
+func appendLine(path, line string) {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		panic(err)
+	}
+	defer f.Close()
+	if _, err := f.WriteString(line + "\n"); err != nil {
+		panic(err)
 	}
 }


### PR DESCRIPTION
## Summary
- add a sink factory and source indirections so deferred sources can be flushed deterministically
- flush sink results again after deferred sources complete to ensure reports capture their output
- add a regression test covering HTTPX deferred execution and verifying report content

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68dd3facb88883298c5552de3d65e9c3