### PR TITLE
Show running tool in progress bar

### DIFF
--- a/internal/app/progress.go
+++ b/internal/app/progress.go
@@ -51,6 +51,7 @@ func (p *progressBar) Wrap(tool string, fn func() error) func() error {
 		return fn
 	}
 	return func() error {
+		p.StepRunning(tool)
 		err := fn()
 		status := "ok"
 		if err != nil {
@@ -66,6 +67,20 @@ func (p *progressBar) Wrap(tool string, fn func() error) func() error {
 		p.StepDone(tool, status)
 		return err
 	}
+}
+
+func (p *progressBar) StepRunning(tool string) {
+	if p == nil || p.total <= 0 {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.done {
+		return
+	}
+
+	p.renderLocked(tool, "ejecutando")
 }
 
 func (p *progressBar) StepDone(tool, status string) {

--- a/internal/app/progress_test.go
+++ b/internal/app/progress_test.go
@@ -50,3 +50,14 @@ func TestProgressBarWrapAndMissingTools(t *testing.T) {
 		t.Fatalf("expected buffer to end with newline after completing steps, got: %q", buf.String())
 	}
 }
+
+func TestProgressBarStepRunning(t *testing.T) {
+	var buf bytes.Buffer
+	pb := newProgressBar(2, &buf)
+
+	pb.StepRunning("ToolRun")
+
+	if !strings.Contains(buf.String(), "ToolRun (ejecutando)") {
+		t.Fatalf("expected running status in buffer, got: %q", buf.String())
+	}
+}


### PR DESCRIPTION
## Summary
- render the progress bar with the current tool as soon as a task starts
- expose a StepRunning helper to update the bar and call it from Wrap
- cover the running state with a new unit test

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68dd4e18571c832993a1ffed58d89e58