### PR TITLE
Organize passive-rec output into per-target directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,11 @@ go.work.sum
 # Passive Recon build artifacts
 *.passive
 passive-rec
+**/report.html
+**/*_*/certs/
+**/*_*/domains/
+**/*_*/routes/
+**/*_*/dns/
 
 # env file
 .env

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -96,7 +96,7 @@ func TestRunFlushesBeforeReportForDeferredSources(t *testing.T) {
 		t.Fatalf("expected at least two flushes, got %d", flushCount)
 	}
 
-	reportPath := filepath.Join(dir, "report.html")
+	reportPath := filepath.Join(dir, sanitizeTargetDir(cfg.Target), "report.html")
 	reportData, err := os.ReadFile(reportPath)
 	if err != nil {
 		t.Fatalf("read report: %v", err)
@@ -160,12 +160,12 @@ drained:
 		if trimmed == "" {
 			continue
 		}
-		targetFile := "domains.passive"
+		targetFile := filepath.Join("domains", "domains.passive")
 		if strings.HasPrefix(trimmed, "meta: ") {
 			trimmed = strings.TrimSpace(strings.TrimPrefix(trimmed, "meta: "))
 			targetFile = "meta.passive"
 		} else if strings.Contains(trimmed, "://") || strings.Contains(trimmed, "/") {
-			targetFile = "routes.passive"
+			targetFile = filepath.Join("routes", "routes.passive")
 		}
 		appendLine(filepath.Join(s.outdir, targetFile), trimmed)
 	}
@@ -177,6 +177,9 @@ func (s *testSink) Close() error {
 }
 
 func appendLine(path, line string) {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		panic(err)
+	}
 	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
 	if err != nil {
 		panic(err)

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -43,13 +43,13 @@ func TestSinkClassification(t *testing.T) {
 		t.Fatalf("Close: %v", err)
 	}
 
-	domains := readLines(t, filepath.Join(dir, "domains.passive"))
+	domains := readLines(t, filepath.Join(dir, "domains", "domains.passive"))
 	wantDomains := []string{"example.com"}
 	if diff := cmp.Diff(wantDomains, domains); diff != "" {
 		t.Fatalf("unexpected domains (-want +got):\n%s", diff)
 	}
 
-	routes := readLines(t, filepath.Join(dir, "routes.passive"))
+	routes := readLines(t, filepath.Join(dir, "routes", "routes.passive"))
 	wantRoutes := []string{
 		"https://app.example.com/login",
 		"http://example.com/about",
@@ -59,7 +59,7 @@ func TestSinkClassification(t *testing.T) {
 		t.Fatalf("unexpected routes (-want +got):\n%s", diff)
 	}
 
-	certs := readLines(t, filepath.Join(dir, "certs.passive"))
+	certs := readLines(t, filepath.Join(dir, "certs", "certs.passive"))
 	wantCerts := []string{"alt1.example.com", "alt2.example.com", "alt3.example.com", "direct-cert.example.com"}
 	if diff := cmp.Diff(wantCerts, certs); diff != "" {
 		t.Fatalf("unexpected certs (-want +got):\n%s", diff)
@@ -88,7 +88,7 @@ func TestSinkFlush(t *testing.T) {
 
 	sink.Flush()
 
-	domains := readLines(t, filepath.Join(dir, "domains.passive"))
+	domains := readLines(t, filepath.Join(dir, "domains", "domains.passive"))
 	wantDomains := []string{"one.example.com", "two.example.com"}
 	sort.Strings(domains)
 	if diff := cmp.Diff(wantDomains, domains); diff != "" {
@@ -109,11 +109,15 @@ func TestNewSinkClosesWritersOnError(t *testing.T) {
 	// Force the second writer creation to fail by pre-creating a directory with
 	// the same name. os.OpenFile will return an error because the path points to
 	// a directory instead of a regular file.
-	if err := os.Mkdir(filepath.Join(dir, "routes.passive"), 0o755); err != nil {
+	routesDir := filepath.Join(dir, "routes")
+	if err := os.MkdirAll(routesDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll routes dir: %v", err)
+	}
+	if err := os.Mkdir(filepath.Join(routesDir, "routes.passive"), 0o755); err != nil {
 		t.Fatalf("Mkdir routes.passive: %v", err)
 	}
 
-	domainPath := filepath.Join(dir, "domains.passive")
+	domainPath := filepath.Join(dir, "domains", "domains.passive")
 	if got := countOpenFDs(t, domainPath); got != 0 {
 		t.Fatalf("unexpected open descriptors before NewSink: %d", got)
 	}

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -26,9 +26,9 @@ type SinkFiles struct {
 // DefaultSinkFiles returns the expected sink file paths within outDir.
 func DefaultSinkFiles(outDir string) SinkFiles {
 	return SinkFiles{
-		Domains: filepath.Join(outDir, "domains.passive"),
-		Routes:  filepath.Join(outDir, "routes.passive"),
-		Certs:   filepath.Join(outDir, "certs.passive"),
+		Domains: filepath.Join(outDir, "domains", "domains.passive"),
+		Routes:  filepath.Join(outDir, "routes", "routes.passive"),
+		Certs:   filepath.Join(outDir, "certs", "certs.passive"),
 		Meta:    filepath.Join(outDir, "meta.passive"),
 	}
 }

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -14,18 +14,18 @@ func TestGenerateCreatesHTMLReport(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	writeFixture(t, filepath.Join(dir, "domains.passive"), strings.Join([]string{
+	writeFixture(t, filepath.Join(dir, "domains", "domains.passive"), strings.Join([]string{
 		"app.example.com",
 		"api.example.com",
 		"static.test.com",
 		"deep.a.b.example.com",
 	}, "\n"))
-	writeFixture(t, filepath.Join(dir, "routes.passive"), strings.Join([]string{
+	writeFixture(t, filepath.Join(dir, "routes", "routes.passive"), strings.Join([]string{
 		"http://app.example.com/login",
 		"https://app.example.com/dashboard",
 		"https://static.example.com/assets/img/logo.png",
 	}, "\n"))
-	writeFixture(t, filepath.Join(dir, "certs.passive"), strings.Join([]string{
+	writeFixture(t, filepath.Join(dir, "certs", "certs.passive"), strings.Join([]string{
 		"alt1.example.com",
 		"alt2.example.com",
 		"service.test.com",
@@ -84,6 +84,9 @@ func TestGenerateHandlesMissingFiles(t *testing.T) {
 
 func writeFixture(t *testing.T, path, contents string) {
 	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", filepath.Dir(path), err)
+	}
 	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", path, err)
 	}


### PR DESCRIPTION
## Summary
- derive the effective output directory from the target and create it before starting the sink
- write sink artifacts into certs/domains/routes subfolders (creating a dns folder) and update report paths accordingly
- refresh supporting tests and .gitignore patterns for the new directory layout

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68de5fe437c48329afefe6012ce1df39