### PR TITLE
Improve httpx batching with concurrency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,9 @@
 module passive-rec
 
-go 1.22
+go 1.24.0
+
+toolchain go1.24.3
 
 require github.com/google/go-cmp v0.6.0
+
+require golang.org/x/sync v0.17.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+golang.org/x/sync v0.17.0 h1:l60nONMj9l5drqw6jlhIELNv9I0A4OFgRsG9k2oT9Ug=
+golang.org/x/sync v0.17.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=

--- a/internal/sources/httpx_test.go
+++ b/internal/sources/httpx_test.go
@@ -31,12 +31,15 @@ func TestHTTPXCombinesAllLists(t *testing.T) {
 
 	originalBinFinder := httpxBinFinder
 	originalRunCmd := httpxRunCmd
+	originalWorkerCount := httpxWorkerCount
 	t.Cleanup(func() {
 		httpxBinFinder = originalBinFinder
 		httpxRunCmd = originalRunCmd
+		httpxWorkerCount = originalWorkerCount
 	})
 
 	httpxBinFinder = func() (string, error) { return "httpx", nil }
+	httpxWorkerCount = 1
 
 	var mu sync.Mutex
 	var gotArgs [][]string
@@ -93,12 +96,15 @@ func TestHTTPXSkipsMissingLists(t *testing.T) {
 
 	originalBinFinder := httpxBinFinder
 	originalRunCmd := httpxRunCmd
+	originalWorkerCount := httpxWorkerCount
 	t.Cleanup(func() {
 		httpxBinFinder = originalBinFinder
 		httpxRunCmd = originalRunCmd
+		httpxWorkerCount = originalWorkerCount
 	})
 
 	httpxBinFinder = func() (string, error) { return "httpx", nil }
+	httpxWorkerCount = 1
 
 	var mu sync.Mutex
 	var captured [][]string
@@ -151,12 +157,15 @@ func TestHTTPXNormalizesOutput(t *testing.T) {
 
 	originalBinFinder := httpxBinFinder
 	originalRunCmd := httpxRunCmd
+	originalWorkerCount := httpxWorkerCount
 	t.Cleanup(func() {
 		httpxBinFinder = originalBinFinder
 		httpxRunCmd = originalRunCmd
+		httpxWorkerCount = originalWorkerCount
 	})
 
 	httpxBinFinder = func() (string, error) { return "httpx", nil }
+	httpxWorkerCount = 1
 
 	httpxRunCmd = func(ctx context.Context, name string, args []string, out chan<- string) error {
 		out <- "https://app.example.com [200] [Title]"
@@ -284,14 +293,17 @@ func TestHTTPXBatchesLargeInputs(t *testing.T) {
 	originalBinFinder := httpxBinFinder
 	originalRunCmd := httpxRunCmd
 	originalBatchSize := httpxBatchSize
+	originalWorkerCount := httpxWorkerCount
 	t.Cleanup(func() {
 		httpxBinFinder = originalBinFinder
 		httpxRunCmd = originalRunCmd
 		httpxBatchSize = originalBatchSize
+		httpxWorkerCount = originalWorkerCount
 	})
 
 	httpxBinFinder = func() (string, error) { return "httpx", nil }
 	httpxBatchSize = 2
+	httpxWorkerCount = 2
 
 	var mu sync.Mutex
 	var captured [][]string
@@ -353,12 +365,15 @@ func TestHTTPXSkipsLowPriorityRoutes(t *testing.T) {
 
 	originalBinFinder := httpxBinFinder
 	originalRunCmd := httpxRunCmd
+	originalWorkerCount := httpxWorkerCount
 	t.Cleanup(func() {
 		httpxBinFinder = originalBinFinder
 		httpxRunCmd = originalRunCmd
+		httpxWorkerCount = originalWorkerCount
 	})
 
 	httpxBinFinder = func() (string, error) { return "httpx", nil }
+	httpxWorkerCount = 1
 
 	var mu sync.Mutex
 	var inputs [][]string


### PR DESCRIPTION
## Summary
- run httpx batches concurrently so all collected routes are processed more reliably within the timeout window
- allow tests to pin the worker count and add the errgroup dependency used by the new worker pool

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68de672463ec832997d40acefd2abd60