### PR TITLE
Ensure httpx routes populate passive outputs

### DIFF
--- a/internal/out/writer.go
+++ b/internal/out/writer.go
@@ -60,6 +60,13 @@ func normalizeURL(u string) string {
 		u = "http://" + u
 	}
 
+	// If the string already contains whitespace, assume it carries metadata
+	// (e.g. httpx status/title) and keep the original representation so the
+	// additional information remains human-readable.
+	if strings.ContainsAny(u, " \t") {
+		return u
+	}
+
 	parsed, err := url.Parse(u)
 	if err != nil {
 		// Si la URL es inválida devolvemos la versión con esquema para evitar perder datos.

--- a/internal/sources/httpx_test.go
+++ b/internal/sources/httpx_test.go
@@ -209,6 +209,11 @@ func TestHTTPXNormalizesOutput(t *testing.T) {
 		t.Fatalf("unexpected routes.active contents (-want +got):\n%s", diff)
 	}
 
+	passiveRoutes := readLines(filepath.Join(outputDir, "routes", "routes.passive"))
+	if diff := cmp.Diff([]string{"https://app.example.com"}, passiveRoutes); diff != "" {
+		t.Fatalf("unexpected routes.passive contents (-want +got):\n%s", diff)
+	}
+
 	domains := readLines(filepath.Join(outputDir, "domains", "domains.active"))
 	if diff := cmp.Diff([]string{"app.example.com"}, domains); diff != "" {
 		t.Fatalf("unexpected domains.active contents (-want +got):\n%s", diff)


### PR DESCRIPTION
## Summary
- copy the base URL from active httpx findings into routes.passive so the list is always populated
- keep whitespace-bearing routes intact during normalization to preserve httpx metadata
- cover the new behavior with pipeline and httpx unit tests

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68de68f0fe388329b8718b75781b8712