### PR TITLE
Include httpx metadata with active domain output

### DIFF
--- a/internal/out/writer.go
+++ b/internal/out/writer.go
@@ -38,16 +38,29 @@ func normalizeDomain(d string) string {
 	if d == "" {
 		return ""
 	}
+
+	var meta string
+	if i := strings.IndexAny(d, " \t"); i != -1 {
+		meta = strings.TrimSpace(d[i:])
+		d = strings.TrimSpace(d[:i])
+	}
+
 	if i := strings.Index(d, "://"); i != -1 {
 		d = d[i+3:]
 	}
 	if i := strings.IndexAny(d, ":/"); i != -1 {
 		d = d[:i]
 	}
-	if strings.HasPrefix(strings.ToLower(d), "www.") {
-		d = d[4:]
+
+	lower := strings.ToLower(d)
+	if strings.HasPrefix(lower, "www.") {
+		lower = lower[4:]
 	}
-	return strings.ToLower(d)
+
+	if meta != "" {
+		return lower + " " + meta
+	}
+	return lower
 }
 
 func normalizeURL(u string) string {

--- a/internal/sources/httpx.go
+++ b/internal/sources/httpx.go
@@ -242,7 +242,11 @@ func normalizeHTTPXLine(line string) []string {
 
 	if urlPart != "" {
 		if domain := extractHTTPXDomain(urlPart); domain != "" && shouldEmitHTTPXDomain(hasStatus, statusCode) {
-			out = append(out, domain)
+			combinedDomain := domain
+			if metaPart != "" {
+				combinedDomain = strings.TrimSpace(domain + " " + metaPart)
+			}
+			out = append(out, combinedDomain)
 		}
 	}
 

--- a/internal/sources/httpx_test.go
+++ b/internal/sources/httpx_test.go
@@ -182,7 +182,7 @@ func TestHTTPXNormalizesOutput(t *testing.T) {
 		forwarded = append(forwarded, <-outCh)
 	}
 
-	wantForwarded := []string{"active: https://app.example.com [200] [Title]", "active: app.example.com", "active: meta: [200]", "active: meta: [Title]"}
+	wantForwarded := []string{"active: https://app.example.com [200] [Title]", "active: app.example.com [200] [Title]", "active: meta: [200]", "active: meta: [Title]"}
 	if diff := cmp.Diff(wantForwarded, forwarded); diff != "" {
 		t.Fatalf("unexpected forwarded lines (-want +got):\n%s", diff)
 	}
@@ -224,7 +224,7 @@ func TestHTTPXNormalizesOutput(t *testing.T) {
 	}
 
 	domains := readLines(filepath.Join(outputDir, "domains", "domains.active"))
-	if diff := cmp.Diff([]string{"app.example.com"}, domains); diff != "" {
+	if diff := cmp.Diff([]string{"app.example.com [200] [Title]"}, domains); diff != "" {
 		t.Fatalf("unexpected domains.active contents (-want +got):\n%s", diff)
 	}
 
@@ -269,11 +269,11 @@ func TestHTTPXSkipsUnresponsiveResults(t *testing.T) {
 	}
 
 	want := []string{
-		"active: down.example.com",
+		"active: down.example.com [0] [connection refused]",
 		"active: meta: [0]",
 		"active: meta: [connection refused]",
 		"active: https://up.example.com [200] [OK]",
-		"active: up.example.com",
+		"active: up.example.com [200] [OK]",
 		"active: meta: [200]",
 		"active: meta: [OK]",
 	}


### PR DESCRIPTION
## Summary
- preserve httpx metadata when normalizing active domain results and propagate it into domains.active
- deduplicate active domains using normalized domain keys while keeping metadata tags
- adjust httpx source tests to assert the enriched domain outputs

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68de6cfb73d88329878d5fa6a23448f1