### PR TITLE
Add subjs JS discovery stage

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -36,6 +36,7 @@ var (
 	sourceCRTSh       = sources.CRTSH
 	sourceCensys      = sources.Censys
 	sourceHTTPX       = sources.HTTPX
+	sourceSubJS       = sources.SubJS
 )
 
 func Run(cfg *config.Config) error {
@@ -105,6 +106,15 @@ func Run(cfg *config.Config) error {
 				})))
 			} else {
 				sink.In() <- "meta: httpx skipped (requires --active)"
+				bar.StepDone(toolName, "omitido")
+			}
+		case "subjs":
+			if cfg.Active {
+				deferreds = append(deferreds, bar.Wrap(toolName, runWithTimeout(ctx, cfg.TimeoutS, func(c context.Context) error {
+					return sourceSubJS(c, filepath.Join("routes", "routes.active"), cfg.OutDir, sink.In())
+				})))
+			} else {
+				sink.In() <- "meta: subjs skipped (requires --active)"
 				bar.StepDone(toolName, "omitido")
 			}
 		default:

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -182,6 +182,9 @@ drained:
 			} else {
 				targetFile = "meta.passive"
 			}
+		} else if strings.HasPrefix(trimmed, "js: ") {
+			trimmed = strings.TrimSpace(strings.TrimPrefix(trimmed, "js: "))
+			targetFile = filepath.Join("routes", "js", "js.passive")
 		} else if strings.Contains(trimmed, "://") || strings.Contains(trimmed, "/") {
 			if isActive {
 				targetFile = filepath.Join("routes", "routes.active")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,18 +7,16 @@ import (
 )
 
 type Config struct {
-
-	Target    string
-	OutDir    string
-	Workers   int
-	Active    bool
-	Tools     []string
-	TimeoutS  int
-	Verbosity int
-	Report    bool
+	Target          string
+	OutDir          string
+	Workers         int
+	Active          bool
+	Tools           []string
+	TimeoutS        int
+	Verbosity       int
+	Report          bool
 	CensysAPIID     string
 	CensysAPISecret string
-
 }
 
 func ParseFlags() *Config {
@@ -26,7 +24,7 @@ func ParseFlags() *Config {
 	outdir := flag.String("outdir", ".", "Directorio de salida (default: .)")
 	workers := flag.Int("workers", 6, "Número de workers")
 	active := flag.Bool("active", false, "Comprobaciones superficiales activas (httpx)")
-	tools := flag.String("tools", "subfinder,assetfinder,amass,waybackurls,gau,crtsh,httpx", "Herramientas, CSV")
+	tools := flag.String("tools", "subfinder,assetfinder,amass,waybackurls,gau,crtsh,httpx,subjs", "Herramientas, CSV")
 	timeout := flag.Int("timeout", 120, "Timeout por herramienta (segundos)")
 	verbosity := flag.Int("v", 0, "Verbosity (0=silent,1=info,2=debug,3=trace)")
 	report := flag.Bool("report", false, "Generar un informe HTML al finalizar")
@@ -49,16 +47,15 @@ func ParseFlags() *Config {
 
 	return &Config{
 
-		Target:    *target,
-		OutDir:    *outdir,
-		Workers:   *workers,
-		Active:    *active,
-		Tools:     list,
-		TimeoutS:  *timeout,
-		Verbosity: *verbosity,
-		Report:    *report,
+		Target:          *target,
+		OutDir:          *outdir,
+		Workers:         *workers,
+		Active:          *active,
+		Tools:           list,
+		TimeoutS:        *timeout,
+		Verbosity:       *verbosity,
+		Report:          *report,
 		CensysAPIID:     strings.TrimSpace(*censysID),
 		CensysAPISecret: strings.TrimSpace(*censysSecret),
-
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -34,9 +34,9 @@ func TestParseFlagsDefaults(t *testing.T) {
 		t.Fatalf("expected default outdir '.', got %q", cfg.OutDir)
 	}
 
-	if len(cfg.Tools) != 7 {
-		t.Fatalf("expected 7 default tools, got %d", len(cfg.Tools))
-	}
+        if len(cfg.Tools) != 8 {
+                t.Fatalf("expected 8 default tools, got %d", len(cfg.Tools))
+        }
 
 	if cfg.TimeoutS != 120 {
 		t.Fatalf("expected default timeout 120, got %d", cfg.TimeoutS)

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -263,6 +263,30 @@ func TestActiveRoutesPopulatePassive(t *testing.T) {
 	}
 }
 
+func TestJSLinesAreWrittenToFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	sink, err := NewSink(dir)
+	if err != nil {
+		t.Fatalf("NewSink: %v", err)
+	}
+
+	sink.Start(1)
+	sink.In() <- "js: https://static.example.com/app.js"
+	sink.In() <- "active: js: https://static.example.com/app.js"
+
+	if err := sink.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	jsPath := filepath.Join(dir, "routes", "js", "js.passive")
+	jsLines := readLines(t, jsPath)
+	if diff := cmp.Diff([]string{"https://static.example.com/app.js"}, jsLines); diff != "" {
+		t.Fatalf("unexpected js.passive contents (-want +got):\n%s", diff)
+	}
+}
+
 func readLines(t *testing.T, path string) []string {
 	t.Helper()
 

--- a/internal/sources/subjs.go
+++ b/internal/sources/subjs.go
@@ -1,0 +1,267 @@
+package sources
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"time"
+
+	"passive-rec/internal/runner"
+)
+
+var (
+	subjsFindBin      = runner.FindBin
+	subjsRunCmd       = runner.RunCommand
+	subjsValidator    = validateJSURLs
+	subjsWorkerCount  = runtime.NumCPU()
+	subjsHTTPTimeout  = 15 * time.Second
+	subjsClientLoader = func() *http.Client {
+		transport := &http.Transport{
+			Proxy:                 http.ProxyFromEnvironment,
+			ResponseHeaderTimeout: 10 * time.Second,
+		}
+		return &http.Client{Transport: transport, Timeout: subjsHTTPTimeout}
+	}
+)
+
+// SubJS executes the subjs binary using the routes active list as input. It collects
+// the discovered JavaScript URLs, validates that they respond with HTTP 200 and
+// writes the surviving URLs to the sink using the "js:" prefix.
+func SubJS(ctx context.Context, routesFile string, outdir string, out chan<- string) error {
+	bin, ok := subjsFindBin("subjs")
+	if !ok {
+		out <- "active: meta: subjs not found in PATH"
+		return runner.ErrMissingBinary
+	}
+
+	inputs, err := loadSubJSInput(filepath.Join(outdir, routesFile))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			out <- "active: meta: subjs skipped missing input " + routesFile
+			return nil
+		}
+		return err
+	}
+	if len(inputs) == 0 {
+		return nil
+	}
+
+	tmpPath, cleanup, err := writeSubJSInput(inputs)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	intermediate := make(chan string)
+	runErr := make(chan error, 1)
+	go func() {
+		runErr <- subjsRunCmd(ctx, bin, []string{"-i", tmpPath}, intermediate)
+		close(intermediate)
+	}()
+
+	seen := make(map[string]struct{})
+	var candidates []string
+	for line := range intermediate {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		if strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if _, ok := seen[trimmed]; ok {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		candidates = append(candidates, trimmed)
+	}
+
+	if err := <-runErr; err != nil {
+		return err
+	}
+	if len(candidates) == 0 {
+		return nil
+	}
+
+	valid, err := subjsValidator(ctx, candidates)
+	if err != nil {
+		return err
+	}
+	for _, url := range valid {
+		out <- "js: " + url
+	}
+	return nil
+}
+
+func loadSubJSInput(path string) ([]string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	scanner.Buffer(make([]byte, 0, 64*1024), 2*1024*1024)
+	seen := make(map[string]struct{})
+	var inputs []string
+	for scanner.Scan() {
+		line := extractSubJSInput(scanner.Text())
+		if line == "" {
+			continue
+		}
+		if _, ok := seen[line]; ok {
+			continue
+		}
+		seen[line] = struct{}{}
+		inputs = append(inputs, line)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scan %s: %w", path, err)
+	}
+	return inputs, nil
+}
+
+func extractSubJSInput(line string) string {
+	trimmed := strings.TrimSpace(line)
+	if trimmed == "" {
+		return ""
+	}
+	if strings.HasPrefix(trimmed, "#") {
+		return ""
+	}
+	if idx := strings.IndexAny(trimmed, " \t"); idx != -1 {
+		trimmed = trimmed[:idx]
+	}
+	trimmed = strings.TrimSpace(trimmed)
+	if trimmed == "" {
+		return ""
+	}
+	return trimmed
+}
+
+func writeSubJSInput(lines []string) (string, func(), error) {
+	tmpFile, err := os.CreateTemp("", "passive-rec-subjs-*.txt")
+	if err != nil {
+		return "", nil, err
+	}
+
+	cleanup := func() {
+		tmpFile.Close()
+		os.Remove(tmpFile.Name())
+	}
+
+	writer := bufio.NewWriter(tmpFile)
+	for _, line := range lines {
+		if _, err := writer.WriteString(line + "\n"); err != nil {
+			cleanup()
+			return "", nil, err
+		}
+	}
+	if err := writer.Flush(); err != nil {
+		cleanup()
+		return "", nil, err
+	}
+	if err := tmpFile.Close(); err != nil {
+		cleanup()
+		return "", nil, err
+	}
+	return tmpFile.Name(), cleanup, nil
+}
+
+func validateJSURLs(ctx context.Context, urls []string) ([]string, error) {
+	if len(urls) == 0 {
+		return nil, nil
+	}
+
+	client := subjsClientLoader()
+	if client == nil {
+		client = &http.Client{Timeout: subjsHTTPTimeout}
+	}
+
+	workerCount := subjsWorkerCount
+	if workerCount <= 0 {
+		workerCount = 1
+	}
+
+	jobs := make(chan string)
+	results := make(chan string, workerCount)
+	var wg sync.WaitGroup
+	for i := 0; i < workerCount; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for url := range jobs {
+				if ctx.Err() != nil {
+					return
+				}
+				if checkJSURL(ctx, client, url) {
+					select {
+					case results <- url:
+					case <-ctx.Done():
+						return
+					}
+				}
+			}
+		}()
+	}
+
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+
+	go func() {
+		defer close(jobs)
+		for _, url := range urls {
+			select {
+			case <-ctx.Done():
+				return
+			case jobs <- url:
+			}
+		}
+	}()
+
+	seen := make(map[string]struct{})
+	var valid []string
+	for url := range results {
+		if _, ok := seen[url]; ok {
+			continue
+		}
+		seen[url] = struct{}{}
+		valid = append(valid, url)
+	}
+
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return valid, nil
+}
+
+func checkJSURL(ctx context.Context, client *http.Client, url string) bool {
+	if status, err := doJSRequest(ctx, client, http.MethodHead, url); err == nil && status == http.StatusOK {
+		return true
+	}
+	status, err := doJSRequest(ctx, client, http.MethodGet, url)
+	return err == nil && status == http.StatusOK
+}
+
+func doJSRequest(ctx context.Context, client *http.Client, method, url string) (int, error) {
+	req, err := http.NewRequestWithContext(ctx, method, url, nil)
+	if err != nil {
+		return 0, err
+	}
+	req.Close = true
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	resp.Body.Close()
+	return resp.StatusCode, nil
+}

--- a/internal/sources/subjs_test.go
+++ b/internal/sources/subjs_test.go
@@ -1,0 +1,154 @@
+package sources
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"passive-rec/internal/runner"
+)
+
+func TestSubJSBinaryMissing(t *testing.T) {
+	originalFind := subjsFindBin
+	defer func() { subjsFindBin = originalFind }()
+
+	subjsFindBin = func(names ...string) (string, bool) {
+		return "", false
+	}
+
+	out := make(chan string, 1)
+	err := SubJS(context.Background(), filepath.Join("routes", "routes.active"), t.TempDir(), out)
+	if !errors.Is(err, runner.ErrMissingBinary) {
+		t.Fatalf("expected ErrMissingBinary, got %v", err)
+	}
+	select {
+	case line := <-out:
+		expected := "active: meta: subjs not found in PATH"
+		if line != expected {
+			t.Fatalf("unexpected output: %q", line)
+		}
+	default:
+		t.Fatalf("expected meta output when binary missing")
+	}
+}
+
+func TestSubJSMissingInputFile(t *testing.T) {
+	dir := t.TempDir()
+	originalFind := subjsFindBin
+	subjsFindBin = func(names ...string) (string, bool) { return "subjs", true }
+	originalRun := subjsRunCmd
+	subjsRunCmd = func(ctx context.Context, name string, args []string, out chan<- string) error {
+		t.Fatalf("RunCommand should not be invoked when input is missing")
+		return nil
+	}
+	originalValidator := subjsValidator
+	subjsValidator = func(ctx context.Context, urls []string) ([]string, error) { return nil, nil }
+	t.Cleanup(func() {
+		subjsFindBin = originalFind
+		subjsRunCmd = originalRun
+		subjsValidator = originalValidator
+	})
+
+	out := make(chan string, 1)
+	if err := SubJS(context.Background(), filepath.Join("routes", "routes.active"), dir, out); err != nil {
+		t.Fatalf("SubJS returned error: %v", err)
+	}
+	select {
+	case line := <-out:
+		expected := "active: meta: subjs skipped missing input routes/routes.active"
+		if line != expected {
+			t.Fatalf("unexpected output: %q", line)
+		}
+	default:
+		t.Fatalf("expected meta output for missing input")
+	}
+}
+
+func TestSubJSSuccess(t *testing.T) {
+	dir := t.TempDir()
+	routesDir := filepath.Join(dir, "routes")
+	if err := os.MkdirAll(routesDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll routes: %v", err)
+	}
+	routesActive := filepath.Join(routesDir, "routes.active")
+	if err := os.WriteFile(routesActive, []byte("https://app.example.com/login [200]\nhttps://app.example.com/login\n"), 0o644); err != nil {
+		t.Fatalf("write routes.active: %v", err)
+	}
+
+	var (
+		mu          sync.Mutex
+		receivedCmd []string
+		validatorIn []string
+	)
+
+	originalFind := subjsFindBin
+	originalRun := subjsRunCmd
+	originalValidator := subjsValidator
+	subjsFindBin = func(names ...string) (string, bool) { return "/usr/bin/subjs", true }
+	subjsRunCmd = func(ctx context.Context, name string, args []string, out chan<- string) error {
+		mu.Lock()
+		receivedCmd = append([]string{name}, args...)
+		mu.Unlock()
+		if len(args) != 2 || args[0] != "-i" {
+			t.Fatalf("unexpected args: %v", args)
+		}
+		data, err := os.ReadFile(args[1])
+		if err != nil {
+			t.Fatalf("expected temp input file readable: %v", err)
+		}
+		expectedInput := "https://app.example.com/login\n"
+		if string(data) != expectedInput {
+			t.Fatalf("unexpected input contents: %q", string(data))
+		}
+		out <- "https://app.example.com/static/app.js"
+		out <- "https://app.example.com/static/app.js"
+		out <- "https://cdn.example.com/lib.js"
+		return nil
+	}
+	subjsValidator = func(ctx context.Context, urls []string) ([]string, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		validatorIn = append([]string{}, urls...)
+		return []string{"https://cdn.example.com/lib.js"}, nil
+	}
+	t.Cleanup(func() {
+		subjsFindBin = originalFind
+		subjsRunCmd = originalRun
+		subjsValidator = originalValidator
+	})
+
+	out := make(chan string, 5)
+	if err := SubJS(context.Background(), filepath.Join("routes", "routes.active"), dir, out); err != nil {
+		t.Fatalf("SubJS returned error: %v", err)
+	}
+
+	mu.Lock()
+	cmd := append([]string{}, receivedCmd...)
+	mu.Unlock()
+	if len(cmd) != 3 {
+		t.Fatalf("unexpected command invocation: %v", cmd)
+	}
+	if cmd[0] != "/usr/bin/subjs" || cmd[1] != "-i" {
+		t.Fatalf("unexpected command args: %v", cmd)
+	}
+
+	mu.Lock()
+	validatorArgs := append([]string{}, validatorIn...)
+	mu.Unlock()
+	if len(validatorArgs) != 2 {
+		t.Fatalf("expected deduplicated output, got %v", validatorArgs)
+	}
+
+	select {
+	case line := <-out:
+		if line != "js: https://cdn.example.com/lib.js" {
+			t.Fatalf("unexpected sink output: %q", line)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("expected sink output")
+	}
+}


### PR DESCRIPTION
## Summary
- add a routes/js writer to the sink and cover it with unit tests
- integrate a new subjs source that validates JavaScript URLs return HTTP 200 before emitting them
- wire the stage into the app defaults and configuration, including CLI defaults and unit coverage

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68de8bdce80c8329ae09700a3bb367a2