### PR TITLE
Ensure active JS and HTML outputs are written

### DIFF
--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -156,6 +156,10 @@ func NewSink(outdir string) (*Sink, error) {
 	if err != nil {
 		return nil, err
 	}
+	jsActive, err := newWriter(filepath.Join("routes", "js"), "js.active")
+	if err != nil {
+		return nil, err
+	}
 	htmlActive, err := newWriter(filepath.Join("routes", "html"), "html.active")
 	if err != nil {
 		return nil, err
@@ -176,7 +180,7 @@ func NewSink(outdir string) (*Sink, error) {
 	s := &Sink{
 		Domains:            writerPair{passive: dPassive, active: dActive},
 		Routes:             writerPair{passive: rPassive, active: rActive},
-		RoutesJS:           writerPair{passive: jsPassive},
+		RoutesJS:           writerPair{passive: jsPassive, active: jsActive},
 		RoutesHTML:         writerPair{active: htmlActive},
 		Certs:              writerPair{passive: cPassive},
 		Meta:               writerPair{passive: mPassive, active: mActive},
@@ -257,11 +261,17 @@ func (s *Sink) processLine(ln string) {
 		if js == "" {
 			return
 		}
+		if isActive {
+			if s.RoutesJS.active != nil {
+				_ = s.RoutesJS.active.WriteURL(js)
+			}
+			if s.RoutesJS.passive != nil {
+				_ = s.RoutesJS.passive.WriteURL(js)
+			}
+			return
+		}
 		if s.RoutesJS.passive != nil {
 			_ = s.RoutesJS.passive.WriteURL(js)
-		}
-		if isActive && s.RoutesJS.active != nil {
-			_ = s.RoutesJS.active.WriteURL(js)
 		}
 		return
 	}

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -280,10 +280,39 @@ func TestJSLinesAreWrittenToFile(t *testing.T) {
 		t.Fatalf("Close: %v", err)
 	}
 
-	jsPath := filepath.Join(dir, "routes", "js", "js.passive")
-	jsLines := readLines(t, jsPath)
-	if diff := cmp.Diff([]string{"https://static.example.com/app.js"}, jsLines); diff != "" {
+	passivePath := filepath.Join(dir, "routes", "js", "js.passive")
+	passiveLines := readLines(t, passivePath)
+	if diff := cmp.Diff([]string{"https://static.example.com/app.js"}, passiveLines); diff != "" {
 		t.Fatalf("unexpected js.passive contents (-want +got):\n%s", diff)
+	}
+
+	activePath := filepath.Join(dir, "routes", "js", "js.active")
+	activeLines := readLines(t, activePath)
+	if diff := cmp.Diff([]string{"https://static.example.com/app.js"}, activeLines); diff != "" {
+		t.Fatalf("unexpected js.active contents (-want +got):\n%s", diff)
+	}
+}
+
+func TestHTMLLinesAreWrittenToActiveFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	sink, err := NewSink(dir)
+	if err != nil {
+		t.Fatalf("NewSink: %v", err)
+	}
+
+	sink.Start(1)
+	sink.In() <- "active: html: https://app.example.com"
+
+	if err := sink.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	htmlPath := filepath.Join(dir, "routes", "html", "html.active")
+	htmlLines := readLines(t, htmlPath)
+	if diff := cmp.Diff([]string{"https://app.example.com"}, htmlLines); diff != "" {
+		t.Fatalf("unexpected html.active contents (-want +got):\n%s", diff)
 	}
 }
 


### PR DESCRIPTION
## Summary
- create dedicated js.active writer so active JS findings are persisted
- write JS lines to the active file when running in active mode and cover HTML routes
- extend pipeline tests to validate active JS and HTML outputs

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68de97d2ff6883299aceffa32be790fc