### PR TITLE
Add categorized route outputs

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -25,8 +25,8 @@ type sink interface {
 }
 
 var (
-	sinkFactory = func(outdir string) (sink, error) {
-		return pipeline.NewSink(outdir)
+	sinkFactory = func(outdir string, active bool) (sink, error) {
+		return pipeline.NewSink(outdir, active)
 	}
 	sourceSubfinder   = sources.Subfinder
 	sourceAssetfinder = sources.Assetfinder
@@ -47,7 +47,7 @@ func Run(cfg *config.Config) error {
 	cfg.OutDir = outDir
 
 	// preparar sink (writers)
-	sink, err := sinkFactory(cfg.OutDir)
+	sink, err := sinkFactory(cfg.OutDir, cfg.Active)
 	if err != nil {
 		return err
 	}

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -58,7 +58,7 @@ func TestRunFlushesBeforeReportForDeferredSources(t *testing.T) {
 		flushes int
 	)
 
-	sinkFactory = func(outdir string) (sink, error) {
+	sinkFactory = func(outdir string, active bool) (sink, error) {
 		ts, err := newTestSink(outdir)
 		if err != nil {
 			return nil, err

--- a/internal/sources/httpx_test.go
+++ b/internal/sources/httpx_test.go
@@ -217,7 +217,7 @@ func TestHTTPXNormalizesOutput(t *testing.T) {
 	}
 
 	outputDir := t.TempDir()
-	sink, err := pipeline.NewSink(outputDir)
+	sink, err := pipeline.NewSink(outputDir, false)
 	if err != nil {
 		t.Fatalf("new sink: %v", err)
 	}


### PR DESCRIPTION
## Summary
- add lazy route writers that infer maps/json/api/wasm/svg/crawl/meta folders and honor active mode naming
- update the sink factory wiring to pass the active flag and adjust associated tests
- add unit tests covering passive and active categorization of new route buckets

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68de9dc5490c832988db5c8b9d5dcb39