### PR TITLE
Filter failing routes from active categories

### DIFF
--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -443,6 +443,28 @@ func TestRouteCategorizationActiveMode(t *testing.T) {
 	}
 }
 
+func TestRouteCategorizationActiveModeSkipsErrorStatus(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	sink, err := NewSink(dir, true)
+	if err != nil {
+		t.Fatalf("NewSink: %v", err)
+	}
+
+	sink.Start(1)
+	sink.In() <- "active: https://app.example.com/static/config.json [404] [Not Found]"
+
+	if err := sink.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	jsonPath := filepath.Join(dir, "routes", "json", "json.active")
+	if _, err := os.Stat(jsonPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected no json.active file, got err=%v", err)
+	}
+}
+
 func readLines(t *testing.T, path string) []string {
 	t.Helper()
 


### PR DESCRIPTION
## Summary
- parse active route metadata to extract HTTP status codes when available
- avoid writing active route categories for responses with failing status codes
- add regression test that ensures 404 responses do not create active JSON route files

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68dea26aa8448329b993cafe8cc22c55