### PR TITLE
Add configuration file support to flag parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,63 @@ go run ./cmd/passive-rec -target example.com -outdir out -report
 
 The report is saved as `report.html` inside the selected output directory.
 
+### Configuration file
+
+You can pre-populate the CLI flags with a YAML or JSON configuration file by passing its path through `--config`:
+
+```
+go run ./cmd/passive-rec --config config.yaml
+```
+
+If a value is present both in the config file and as a CLI flag, the CLI flag wins. Supported keys are:
+
+| Campo              | Tipo                | Descripción                                      |
+|--------------------|---------------------|--------------------------------------------------|
+| `target`           | string              | Dominio objetivo                                 |
+| `outdir`           | string              | Directorio de salida                             |
+| `workers`          | int                 | Número de workers concurrentes                   |
+| `active`           | bool                | Ejecuta comprobaciones activas                   |
+| `tools`            | lista o CSV         | Herramientas a ejecutar                          |
+| `timeout`          | int                 | Timeout por herramienta en segundos              |
+| `verbosity`        | int                 | Nivel de verbosidad (0-3)                        |
+| `report`           | bool                | Genera informe HTML                              |
+| `censys_api_id`    | string              | Credencial Censys API ID                         |
+| `censys_api_secret`| string              | Credencial Censys API Secret                     |
+
+A YAML example:
+
+```yaml
+target: example.com
+outdir: out
+workers: 10
+active: true
+tools:
+  - subfinder
+  - amass
+timeout: 180
+verbosity: 1
+report: true
+censys_api_id: "${CENSYS_API_ID}"
+censys_api_secret: "${CENSYS_API_SECRET}"
+```
+
+The same configuration in JSON:
+
+```json
+{
+  "target": "example.com",
+  "outdir": "out",
+  "workers": 10,
+  "active": true,
+  "tools": ["subfinder", "amass"],
+  "timeout": 180,
+  "verbosity": 1,
+  "report": true,
+  "censys_api_id": "${CENSYS_API_ID}",
+  "censys_api_secret": "${CENSYS_API_SECRET}"
+}
+```
+
 ## Censys certificates integration
 
 The `censys` source consumes the [Censys Search API](https://search.censys.io/api) to enumerate hosts from the certificate corpus. You must supply your account credentials through the new flags or environment variables:

--- a/go.mod
+++ b/go.mod
@@ -9,3 +9,5 @@ require (
 	golang.org/x/net v0.44.0
 	golang.org/x/sync v0.17.0
 )
+
+require gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,3 +4,6 @@ golang.org/x/net v0.44.0 h1:evd8IRDyfNBMBTTY5XRF1vaZlD+EmWx6x8PkhR04H/I=
 golang.org/x/net v0.44.0/go.mod h1:ECOoLqd5U3Lhyeyo/QDCEVQ4sNgYsqvCZ722XogGieY=
 golang.org/x/sync v0.17.0 h1:l60nONMj9l5drqw6jlhIELNv9I0A4OFgRsG9k2oT9Ug=
 golang.org/x/sync v0.17.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,9 +1,16 @@
 package config
 
 import (
+	"bytes"
+	"encoding/json"
+	"errors"
 	"flag"
+	"log"
 	"os"
+	"path/filepath"
 	"strings"
+
+	"gopkg.in/yaml.v3"
 )
 
 type Config struct {
@@ -19,7 +26,70 @@ type Config struct {
 	CensysAPISecret string
 }
 
+type fileConfig struct {
+	Target          *string     `json:"target" yaml:"target"`
+	OutDir          *string     `json:"outdir" yaml:"outdir"`
+	Workers         *int        `json:"workers" yaml:"workers"`
+	Active          *bool       `json:"active" yaml:"active"`
+	Tools           *stringList `json:"tools" yaml:"tools"`
+	TimeoutS        *int        `json:"timeout" yaml:"timeout"`
+	Verbosity       *int        `json:"verbosity" yaml:"verbosity"`
+	Report          *bool       `json:"report" yaml:"report"`
+	CensysAPIID     *string     `json:"censys_api_id" yaml:"censys_api_id"`
+	CensysAPISecret *string     `json:"censys_api_secret" yaml:"censys_api_secret"`
+}
+
+type stringList []string
+
+func (s *stringList) UnmarshalJSON(data []byte) error {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		*s = nil
+		return nil
+	}
+
+	switch trimmed[0] {
+	case '[':
+		var aux []string
+		if err := json.Unmarshal(trimmed, &aux); err != nil {
+			return err
+		}
+		*s = cleanStringSlice(aux)
+		return nil
+	case '"':
+		var single string
+		if err := json.Unmarshal(trimmed, &single); err != nil {
+			return err
+		}
+		*s = cleanStringSlice(strings.Split(single, ","))
+		return nil
+	default:
+		return errors.New("tools debe ser un string o una lista")
+	}
+}
+
+func (s *stringList) UnmarshalYAML(value *yaml.Node) error {
+	switch value.Kind {
+	case yaml.SequenceNode:
+		aux := make([]string, 0, len(value.Content))
+		for _, node := range value.Content {
+			aux = append(aux, node.Value)
+		}
+		*s = cleanStringSlice(aux)
+		return nil
+	case yaml.ScalarNode:
+		*s = cleanStringSlice(strings.Split(value.Value, ","))
+		return nil
+	case yaml.MappingNode, yaml.DocumentNode:
+		return errors.New("tools debe ser un string o una lista")
+	default:
+		*s = nil
+		return nil
+	}
+}
+
 func ParseFlags() *Config {
+	configPath := flag.String("config", "", "Ruta a un archivo de configuración (YAML o JSON)")
 	target := flag.String("target", "", "Target domain (ej: example.com)")
 	outdir := flag.String("outdir", ".", "Directorio de salida (default: .)")
 	workers := flag.Int("workers", 6, "Número de workers")
@@ -33,22 +103,16 @@ func ParseFlags() *Config {
 
 	flag.Parse()
 
-	list := []string{}
-	for _, t := range strings.Split(*tools, ",") {
-		t = strings.TrimSpace(t)
-		if t != "" {
-			list = append(list, t)
-		}
-	}
+	setFlags := map[string]bool{}
+	flag.Visit(func(f *flag.Flag) {
+		setFlags[f.Name] = true
+	})
 
-	if *outdir == "" {
-		*outdir = "."
-	}
+	list := cleanStringSlice(strings.Split(*tools, ","))
 
-	return &Config{
-
-		Target:          *target,
-		OutDir:          *outdir,
+	cfg := &Config{
+		Target:          strings.TrimSpace(*target),
+		OutDir:          strings.TrimSpace(*outdir),
 		Workers:         *workers,
 		Active:          *active,
 		Tools:           list,
@@ -58,4 +122,100 @@ func ParseFlags() *Config {
 		CensysAPIID:     strings.TrimSpace(*censysID),
 		CensysAPISecret: strings.TrimSpace(*censysSecret),
 	}
+
+	var fileCfg *fileConfig
+	if *configPath != "" {
+		info, err := os.Stat(*configPath)
+		if err != nil {
+			if !errors.Is(err, os.ErrNotExist) {
+				log.Fatalf("no se pudo acceder al archivo de configuración %q: %v", *configPath, err)
+			}
+		} else if info.IsDir() {
+			log.Fatalf("la ruta de configuración %q apunta a un directorio", *configPath)
+		} else {
+			fc, err := loadConfigFile(*configPath)
+			if err != nil {
+				log.Fatalf("no se pudo leer la configuración desde %q: %v", *configPath, err)
+			}
+			fileCfg = fc
+		}
+	}
+
+	if fileCfg != nil {
+		if fileCfg.Target != nil && !setFlags["target"] {
+			cfg.Target = strings.TrimSpace(*fileCfg.Target)
+		}
+		if fileCfg.OutDir != nil && !setFlags["outdir"] {
+			cfg.OutDir = strings.TrimSpace(*fileCfg.OutDir)
+		}
+		if fileCfg.Workers != nil && !setFlags["workers"] {
+			cfg.Workers = *fileCfg.Workers
+		}
+		if fileCfg.Active != nil && !setFlags["active"] {
+			cfg.Active = *fileCfg.Active
+		}
+		if fileCfg.Tools != nil && !setFlags["tools"] {
+			cfg.Tools = cleanStringSlice([]string(*fileCfg.Tools))
+		}
+		if fileCfg.TimeoutS != nil && !setFlags["timeout"] {
+			cfg.TimeoutS = *fileCfg.TimeoutS
+		}
+		if fileCfg.Verbosity != nil && !setFlags["v"] {
+			cfg.Verbosity = *fileCfg.Verbosity
+		}
+		if fileCfg.Report != nil && !setFlags["report"] {
+			cfg.Report = *fileCfg.Report
+		}
+		if fileCfg.CensysAPIID != nil && !setFlags["censys-api-id"] {
+			cfg.CensysAPIID = strings.TrimSpace(*fileCfg.CensysAPIID)
+		}
+		if fileCfg.CensysAPISecret != nil && !setFlags["censys-api-secret"] {
+			cfg.CensysAPISecret = strings.TrimSpace(*fileCfg.CensysAPISecret)
+		}
+	}
+
+	if cfg.OutDir == "" {
+		cfg.OutDir = "."
+	}
+
+	return cfg
+}
+
+func loadConfigFile(path string) (*fileConfig, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var cfg fileConfig
+	ext := strings.ToLower(filepath.Ext(path))
+	switch ext {
+	case ".yaml", ".yml":
+		if err := yaml.Unmarshal(raw, &cfg); err != nil {
+			return nil, err
+		}
+	case ".json":
+		if err := json.Unmarshal(raw, &cfg); err != nil {
+			return nil, err
+		}
+	default:
+		if err := yaml.Unmarshal(raw, &cfg); err != nil {
+			if err := json.Unmarshal(raw, &cfg); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return &cfg, nil
+}
+
+func cleanStringSlice(values []string) []string {
+	list := make([]string, 0, len(values))
+	for _, v := range values {
+		v = strings.TrimSpace(v)
+		if v != "" {
+			list = append(list, v)
+		}
+	}
+	return list
 }


### PR DESCRIPTION
## Summary
- add a --config flag that reads optional YAML or JSON files
- merge file settings with CLI flags while letting explicit CLI options win
- document the configuration format and supported fields in the README

## Testing
- not run (tests hang locally: go test ./...)


------
https://chatgpt.com/codex/tasks/task_e_68dea5404cc08329baa72f43d77bbf30