### PR TITLE
Mark SubJS discoveries as active JavaScript

### DIFF
--- a/internal/sources/subjs.go
+++ b/internal/sources/subjs.go
@@ -34,7 +34,8 @@ var (
 
 // SubJS executes the subjs binary using the routes active list as input. It collects
 // the discovered JavaScript URLs, validates that they respond with HTTP 200 and
-// writes the surviving URLs to the sink using the "js:" prefix.
+// writes the surviving URLs to the sink using the "active: js:" prefix so they
+// are tracked as active findings.
 func SubJS(ctx context.Context, routesFile string, outdir string, out chan<- string) error {
 	bin, ok := subjsFindBin("subjs")
 	if !ok {
@@ -96,7 +97,7 @@ func SubJS(ctx context.Context, routesFile string, outdir string, out chan<- str
 		return err
 	}
 	for _, url := range valid {
-		out <- "js: " + url
+		out <- "active: js: " + url
 	}
 	return nil
 }

--- a/internal/sources/subjs_test.go
+++ b/internal/sources/subjs_test.go
@@ -145,7 +145,7 @@ func TestSubJSSuccess(t *testing.T) {
 
 	select {
 	case line := <-out:
-		if line != "js: https://cdn.example.com/lib.js" {
+		if line != "active: js: https://cdn.example.com/lib.js" {
 			t.Fatalf("unexpected sink output: %q", line)
 		}
 	case <-time.After(time.Second):


### PR DESCRIPTION
## Summary
- update SubJS to tag discovered JavaScript URLs with the active prefix so they land in js.active
- refresh the SubJS tests to expect the new active prefix

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68deab2550e083299eac4b179b942a26