### PR TITLE
Preserve httpx labels in active route outputs

### DIFF
--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -68,6 +68,20 @@ func (lw *lazyWriter) WriteURL(u string) {
 	_ = w.WriteURL(u)
 }
 
+func (lw *lazyWriter) WriteRaw(line string) {
+	if lw == nil {
+		return
+	}
+	if line == "" {
+		return
+	}
+	w, err := lw.ensure()
+	if err != nil {
+		return
+	}
+	_ = w.WriteRaw(line)
+}
+
 func (lw *lazyWriter) Close() {
 	if lw == nil {
 		return
@@ -361,7 +375,7 @@ func (s *Sink) processLine(ln string) {
 		}
 		if isActive {
 			if s.RoutesJS.active != nil {
-				_ = s.RoutesJS.active.WriteURL(js)
+				_ = s.RoutesJS.active.WriteRaw("js: " + js)
 			}
 			if s.RoutesJS.passive != nil {
 				_ = s.RoutesJS.passive.WriteURL(js)
@@ -389,6 +403,10 @@ func (s *Sink) processLine(ln string) {
 			return
 		}
 		if seen != nil && s.markSeen(seen, html) {
+			return
+		}
+		if isActive {
+			_ = writer.WriteRaw("html: " + html)
 			return
 		}
 		_ = writer.WriteURL(html)
@@ -613,31 +631,59 @@ func (s *Sink) writeRouteCategories(route string, isActive bool) {
 		switch cat {
 		case routeCategoryMaps:
 			if s.RoutesMaps != nil && !s.markSeen(s.seenRoutesMaps, route) {
-				s.RoutesMaps.WriteURL(route)
+				if s.activeMode && isActive {
+					s.RoutesMaps.WriteRaw("maps: " + route)
+				} else {
+					s.RoutesMaps.WriteURL(route)
+				}
 			}
 		case routeCategoryJSON:
 			if s.RoutesJSON != nil && !s.markSeen(s.seenRoutesJSON, route) {
-				s.RoutesJSON.WriteURL(route)
+				if s.activeMode && isActive {
+					s.RoutesJSON.WriteRaw("json: " + route)
+				} else {
+					s.RoutesJSON.WriteURL(route)
+				}
 			}
 		case routeCategoryAPI:
 			if s.RoutesAPI != nil && !s.markSeen(s.seenRoutesAPI, route) {
-				s.RoutesAPI.WriteURL(route)
+				if s.activeMode && isActive {
+					s.RoutesAPI.WriteRaw("api: " + route)
+				} else {
+					s.RoutesAPI.WriteURL(route)
+				}
 			}
 		case routeCategoryWASM:
 			if s.RoutesWASM != nil && !s.markSeen(s.seenRoutesWASM, route) {
-				s.RoutesWASM.WriteURL(route)
+				if s.activeMode && isActive {
+					s.RoutesWASM.WriteRaw("wasm: " + route)
+				} else {
+					s.RoutesWASM.WriteURL(route)
+				}
 			}
 		case routeCategorySVG:
 			if s.RoutesSVG != nil && !s.markSeen(s.seenRoutesSVG, route) {
-				s.RoutesSVG.WriteURL(route)
+				if s.activeMode && isActive {
+					s.RoutesSVG.WriteRaw("svg: " + route)
+				} else {
+					s.RoutesSVG.WriteURL(route)
+				}
 			}
 		case routeCategoryCrawl:
 			if s.RoutesCrawl != nil && !s.markSeen(s.seenRoutesCrawl, route) {
-				s.RoutesCrawl.WriteURL(route)
+				if s.activeMode && isActive {
+					s.RoutesCrawl.WriteRaw("crawl: " + route)
+				} else {
+					s.RoutesCrawl.WriteURL(route)
+				}
 			}
 		case routeCategoryMeta:
 			if s.RoutesMetaFindings != nil && !s.markSeen(s.seenRoutesMeta, route) {
-				s.RoutesMetaFindings.WriteURL(route)
+				if s.activeMode && isActive {
+					s.RoutesMetaFindings.WriteRaw("meta: " + route)
+				} else {
+					s.RoutesMetaFindings.WriteURL(route)
+				}
 			}
 		}
 	}

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -288,7 +288,7 @@ func TestJSLinesAreWrittenToFile(t *testing.T) {
 
 	activePath := filepath.Join(dir, "routes", "js", "js.active")
 	activeLines := readLines(t, activePath)
-	if diff := cmp.Diff([]string{"https://static.example.com/app.js"}, activeLines); diff != "" {
+	if diff := cmp.Diff([]string{"js: https://static.example.com/app.js"}, activeLines); diff != "" {
 		t.Fatalf("unexpected js.active contents (-want +got):\n%s", diff)
 	}
 }
@@ -311,7 +311,7 @@ func TestHTMLLinesAreWrittenToActiveFile(t *testing.T) {
 
 	htmlPath := filepath.Join(dir, "routes", "html", "html.active")
 	htmlLines := readLines(t, htmlPath)
-	if diff := cmp.Diff([]string{"https://app.example.com"}, htmlLines); diff != "" {
+	if diff := cmp.Diff([]string{"html: https://app.example.com"}, htmlLines); diff != "" {
 		t.Fatalf("unexpected html.active contents (-want +got):\n%s", diff)
 	}
 }
@@ -421,17 +421,17 @@ func TestRouteCategorizationActiveMode(t *testing.T) {
 
 	mapsPath := filepath.Join(dir, "routes", "maps", "maps.active")
 	mapsLines := readLines(t, mapsPath)
-	if diff := cmp.Diff([]string{"https://app.example.com/static/app.js.map"}, mapsLines); diff != "" {
+	if diff := cmp.Diff([]string{"maps: https://app.example.com/static/app.js.map"}, mapsLines); diff != "" {
 		t.Fatalf("unexpected maps.active contents (-want +got):\n%s", diff)
 	}
 
 	jsonLines := readLines(t, filepath.Join(dir, "routes", "json", "json.active"))
-	if diff := cmp.Diff([]string{"https://app.example.com/static/manifest.json"}, jsonLines); diff != "" {
+	if diff := cmp.Diff([]string{"json: https://app.example.com/static/manifest.json"}, jsonLines); diff != "" {
 		t.Fatalf("unexpected json.active contents (-want +got):\n%s", diff)
 	}
 
 	apiLines := readLines(t, filepath.Join(dir, "routes", "api", "api.active"))
-	if diff := cmp.Diff([]string{"https://app.example.com/static/swagger.json"}, apiLines); diff != "" {
+	if diff := cmp.Diff([]string{"api: https://app.example.com/static/swagger.json"}, apiLines); diff != "" {
 		t.Fatalf("unexpected api.active contents (-want +got):\n%s", diff)
 	}
 

--- a/internal/sources/httpx_test.go
+++ b/internal/sources/httpx_test.go
@@ -263,7 +263,7 @@ func TestHTTPXNormalizesOutput(t *testing.T) {
 	}
 
 	htmlRoutes := readLines(filepath.Join(outputDir, "routes", "html", "html.active"))
-	if diff := cmp.Diff([]string{"https://app.example.com"}, htmlRoutes); diff != "" {
+	if diff := cmp.Diff([]string{"html: https://app.example.com"}, htmlRoutes); diff != "" {
 		t.Fatalf("unexpected html.active contents (-want +got):\n%s", diff)
 	}
 }


### PR DESCRIPTION
## Summary
- keep the httpx-generated prefixes when writing active JS, HTML, and categorized route outputs
- allow lazy writers to emit raw lines so metadata survives in the saved files
- update unit tests to expect the preserved labels

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68deabebbdc8832981d1080b9b5364b0