### PR TITLE
Remove route prefixes from active outputs

### DIFF
--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -375,7 +375,7 @@ func (s *Sink) processLine(ln string) {
 		}
 		if isActive {
 			if s.RoutesJS.active != nil {
-				_ = s.RoutesJS.active.WriteRaw("js: " + js)
+				_ = s.RoutesJS.active.WriteRaw(js)
 			}
 			if s.RoutesJS.passive != nil {
 				_ = s.RoutesJS.passive.WriteURL(js)
@@ -406,7 +406,7 @@ func (s *Sink) processLine(ln string) {
 			return
 		}
 		if isActive {
-			_ = writer.WriteRaw("html: " + html)
+			_ = writer.WriteRaw(html)
 			return
 		}
 		_ = writer.WriteURL(html)
@@ -632,7 +632,7 @@ func (s *Sink) writeRouteCategories(route string, isActive bool) {
 		case routeCategoryMaps:
 			if s.RoutesMaps != nil && !s.markSeen(s.seenRoutesMaps, route) {
 				if s.activeMode && isActive {
-					s.RoutesMaps.WriteRaw("maps: " + route)
+					s.RoutesMaps.WriteRaw(route)
 				} else {
 					s.RoutesMaps.WriteURL(route)
 				}
@@ -640,7 +640,7 @@ func (s *Sink) writeRouteCategories(route string, isActive bool) {
 		case routeCategoryJSON:
 			if s.RoutesJSON != nil && !s.markSeen(s.seenRoutesJSON, route) {
 				if s.activeMode && isActive {
-					s.RoutesJSON.WriteRaw("json: " + route)
+					s.RoutesJSON.WriteRaw(route)
 				} else {
 					s.RoutesJSON.WriteURL(route)
 				}
@@ -648,7 +648,7 @@ func (s *Sink) writeRouteCategories(route string, isActive bool) {
 		case routeCategoryAPI:
 			if s.RoutesAPI != nil && !s.markSeen(s.seenRoutesAPI, route) {
 				if s.activeMode && isActive {
-					s.RoutesAPI.WriteRaw("api: " + route)
+					s.RoutesAPI.WriteRaw(route)
 				} else {
 					s.RoutesAPI.WriteURL(route)
 				}
@@ -656,7 +656,7 @@ func (s *Sink) writeRouteCategories(route string, isActive bool) {
 		case routeCategoryWASM:
 			if s.RoutesWASM != nil && !s.markSeen(s.seenRoutesWASM, route) {
 				if s.activeMode && isActive {
-					s.RoutesWASM.WriteRaw("wasm: " + route)
+					s.RoutesWASM.WriteRaw(route)
 				} else {
 					s.RoutesWASM.WriteURL(route)
 				}
@@ -664,7 +664,7 @@ func (s *Sink) writeRouteCategories(route string, isActive bool) {
 		case routeCategorySVG:
 			if s.RoutesSVG != nil && !s.markSeen(s.seenRoutesSVG, route) {
 				if s.activeMode && isActive {
-					s.RoutesSVG.WriteRaw("svg: " + route)
+					s.RoutesSVG.WriteRaw(route)
 				} else {
 					s.RoutesSVG.WriteURL(route)
 				}
@@ -672,7 +672,7 @@ func (s *Sink) writeRouteCategories(route string, isActive bool) {
 		case routeCategoryCrawl:
 			if s.RoutesCrawl != nil && !s.markSeen(s.seenRoutesCrawl, route) {
 				if s.activeMode && isActive {
-					s.RoutesCrawl.WriteRaw("crawl: " + route)
+					s.RoutesCrawl.WriteRaw(route)
 				} else {
 					s.RoutesCrawl.WriteURL(route)
 				}
@@ -680,7 +680,7 @@ func (s *Sink) writeRouteCategories(route string, isActive bool) {
 		case routeCategoryMeta:
 			if s.RoutesMetaFindings != nil && !s.markSeen(s.seenRoutesMeta, route) {
 				if s.activeMode && isActive {
-					s.RoutesMetaFindings.WriteRaw("meta: " + route)
+					s.RoutesMetaFindings.WriteRaw(route)
 				} else {
 					s.RoutesMetaFindings.WriteURL(route)
 				}

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -288,7 +288,7 @@ func TestJSLinesAreWrittenToFile(t *testing.T) {
 
 	activePath := filepath.Join(dir, "routes", "js", "js.active")
 	activeLines := readLines(t, activePath)
-	if diff := cmp.Diff([]string{"js: https://static.example.com/app.js"}, activeLines); diff != "" {
+	if diff := cmp.Diff([]string{"https://static.example.com/app.js"}, activeLines); diff != "" {
 		t.Fatalf("unexpected js.active contents (-want +got):\n%s", diff)
 	}
 }
@@ -311,7 +311,7 @@ func TestHTMLLinesAreWrittenToActiveFile(t *testing.T) {
 
 	htmlPath := filepath.Join(dir, "routes", "html", "html.active")
 	htmlLines := readLines(t, htmlPath)
-	if diff := cmp.Diff([]string{"html: https://app.example.com"}, htmlLines); diff != "" {
+	if diff := cmp.Diff([]string{"https://app.example.com"}, htmlLines); diff != "" {
 		t.Fatalf("unexpected html.active contents (-want +got):\n%s", diff)
 	}
 }
@@ -380,11 +380,11 @@ func TestRouteCategorizationPassive(t *testing.T) {
 		t.Fatalf("unexpected svg.passive contents (-want +got):\n%s", diff)
 	}
 
-	crawlLines := readLines(t, filepath.Join(dir, "routes", "crawl", "crawl.passive"))
-	wantCrawl := []string{
-		"https://app.example.com/robots.txt",
-		"https://app.example.com/sitemap.xml",
-	}
+        crawlLines := readLines(t, filepath.Join(dir, "routes", "crawl", "crawl.passive"))
+        wantCrawl := []string{
+                "https://app.example.com/robots.txt",
+                "https://app.example.com/sitemap.xml",
+        }
 	if diff := cmp.Diff(wantCrawl, crawlLines); diff != "" {
 		t.Fatalf("unexpected crawl.passive contents (-want +got):\n%s", diff)
 	}
@@ -421,17 +421,17 @@ func TestRouteCategorizationActiveMode(t *testing.T) {
 
 	mapsPath := filepath.Join(dir, "routes", "maps", "maps.active")
 	mapsLines := readLines(t, mapsPath)
-	if diff := cmp.Diff([]string{"maps: https://app.example.com/static/app.js.map"}, mapsLines); diff != "" {
+	if diff := cmp.Diff([]string{"https://app.example.com/static/app.js.map"}, mapsLines); diff != "" {
 		t.Fatalf("unexpected maps.active contents (-want +got):\n%s", diff)
 	}
 
 	jsonLines := readLines(t, filepath.Join(dir, "routes", "json", "json.active"))
-	if diff := cmp.Diff([]string{"json: https://app.example.com/static/manifest.json"}, jsonLines); diff != "" {
+	if diff := cmp.Diff([]string{"https://app.example.com/static/manifest.json"}, jsonLines); diff != "" {
 		t.Fatalf("unexpected json.active contents (-want +got):\n%s", diff)
 	}
 
 	apiLines := readLines(t, filepath.Join(dir, "routes", "api", "api.active"))
-	if diff := cmp.Diff([]string{"api: https://app.example.com/static/swagger.json"}, apiLines); diff != "" {
+	if diff := cmp.Diff([]string{"https://app.example.com/static/swagger.json"}, apiLines); diff != "" {
 		t.Fatalf("unexpected api.active contents (-want +got):\n%s", diff)
 	}
 

--- a/internal/sources/httpx_test.go
+++ b/internal/sources/httpx_test.go
@@ -263,7 +263,7 @@ func TestHTTPXNormalizesOutput(t *testing.T) {
 	}
 
 	htmlRoutes := readLines(filepath.Join(outputDir, "routes", "html", "html.active"))
-	if diff := cmp.Diff([]string{"html: https://app.example.com"}, htmlRoutes); diff != "" {
+	if diff := cmp.Diff([]string{"https://app.example.com"}, htmlRoutes); diff != "" {
 		t.Fatalf("unexpected html.active contents (-want +got):\n%s", diff)
 	}
 }


### PR DESCRIPTION
## Summary
- stop writing prefixed labels such as `js:` or `html:` to active route output files
- update category writers so active-mode outputs contain bare URLs across JSON, API, crawl, and other route types
- refresh related tests to assert the new prefix-free outputs

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68deb00998848329b01e9c52b8305d69