### PR TITLE
Refactor pipeline order and add dedupe stage

### DIFF
--- a/internal/app/dedupe.go
+++ b/internal/app/dedupe.go
@@ -1,0 +1,138 @@
+package app
+
+import (
+	"bufio"
+	"errors"
+	"net"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+func dedupeDomainList(outdir string) ([]string, error) {
+	inputPath := filepath.Join(outdir, "domains", "domains.passive")
+	file, err := os.Open(inputPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			if err := writeDedupeFile(outdir, nil); err != nil {
+				return nil, err
+			}
+			return nil, nil
+		}
+		return nil, err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	scanner.Buffer(make([]byte, 0, 64*1024), 2*1024*1024)
+
+	seen := make(map[string]struct{})
+	var domains []string
+	for scanner.Scan() {
+		normalized := normalizeDedupeDomain(scanner.Text())
+		if normalized == "" {
+			continue
+		}
+		if _, ok := seen[normalized]; ok {
+			continue
+		}
+		seen[normalized] = struct{}{}
+		domains = append(domains, normalized)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	sort.Strings(domains)
+	if err := writeDedupeFile(outdir, domains); err != nil {
+		return nil, err
+	}
+	return domains, nil
+}
+
+func writeDedupeFile(outdir string, domains []string) error {
+	targetDir := filepath.Join(outdir, "domains")
+	if err := os.MkdirAll(targetDir, 0o755); err != nil {
+		return err
+	}
+	outputPath := filepath.Join(targetDir, "domains.dedupe")
+
+	var builder strings.Builder
+	for _, domain := range domains {
+		builder.WriteString(domain)
+		builder.WriteByte('\n')
+	}
+
+	return os.WriteFile(outputPath, []byte(builder.String()), 0o644)
+}
+
+func normalizeDedupeDomain(line string) string {
+	trimmed := strings.TrimSpace(line)
+	if trimmed == "" {
+		return ""
+	}
+	if strings.HasPrefix(trimmed, "#") {
+		return ""
+	}
+	if idx := strings.IndexAny(trimmed, " \t"); idx != -1 {
+		trimmed = trimmed[:idx]
+	}
+	if trimmed == "" {
+		return ""
+	}
+
+	candidate := trimmed
+	var parsed *url.URL
+	var err error
+	if strings.Contains(candidate, "://") {
+		parsed, err = url.Parse(candidate)
+	} else {
+		parsed, err = url.Parse("http://" + candidate)
+	}
+	if err == nil && parsed != nil {
+		hostPort := parsed.Host
+		hostname := parsed.Hostname()
+		if hostname != "" && !(strings.Count(hostPort, ":") > 1 && !strings.Contains(hostPort, "[")) {
+			candidate = hostname
+		} else if hostPort != "" {
+			candidate = hostPort
+		}
+	}
+
+	if candidate == "" {
+		return ""
+	}
+
+	if at := strings.LastIndex(candidate, "@"); at != -1 {
+		candidate = candidate[at+1:]
+	}
+
+	if idx := strings.IndexAny(candidate, "/?#"); idx != -1 {
+		candidate = candidate[:idx]
+	}
+
+	if candidate == "" {
+		return ""
+	}
+
+	if host, _, err := net.SplitHostPort(candidate); err == nil {
+		candidate = host
+	}
+
+	if strings.HasPrefix(candidate, "[") && strings.HasSuffix(candidate, "]") {
+		candidate = strings.Trim(candidate, "[]")
+	}
+
+	lowered := strings.ToLower(candidate)
+	if strings.HasPrefix(lowered, "www.") {
+		lowered = lowered[4:]
+	}
+
+	if strings.Contains(lowered, "*") {
+		return ""
+	}
+
+	return lowered
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -94,7 +94,7 @@ func ParseFlags() *Config {
 	outdir := flag.String("outdir", ".", "Directorio de salida (default: .)")
 	workers := flag.Int("workers", 6, "Número de workers")
 	active := flag.Bool("active", false, "Comprobaciones superficiales activas (httpx)")
-	tools := flag.String("tools", "subfinder,assetfinder,amass,waybackurls,gau,crtsh,httpx,subjs", "Herramientas, CSV")
+	tools := flag.String("tools", "amass,subfinder,assetfinder,crtsh,dedupe,waybackurls,gau,httpx,subjs", "Herramientas, CSV")
 	timeout := flag.Int("timeout", 120, "Timeout por herramienta (segundos)")
 	verbosity := flag.Int("v", 0, "Verbosity (0=silent,1=info,2=debug,3=trace)")
 	report := flag.Bool("report", false, "Generar un informe HTML al finalizar")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -34,9 +34,10 @@ func TestParseFlagsDefaults(t *testing.T) {
 		t.Fatalf("expected default outdir '.', got %q", cfg.OutDir)
 	}
 
-        if len(cfg.Tools) != 8 {
-                t.Fatalf("expected 8 default tools, got %d", len(cfg.Tools))
-        }
+	expectedTools := []string{"amass", "subfinder", "assetfinder", "crtsh", "dedupe", "waybackurls", "gau", "httpx", "subjs"}
+	if !reflect.DeepEqual(cfg.Tools, expectedTools) {
+		t.Fatalf("expected default tools %v, got %v", expectedTools, cfg.Tools)
+	}
 
 	if cfg.TimeoutS != 120 {
 		t.Fatalf("expected default timeout 120, got %d", cfg.TimeoutS)

--- a/internal/sources/gau.go
+++ b/internal/sources/gau.go
@@ -2,16 +2,57 @@ package sources
 
 import (
 	"context"
+	"runtime"
+	"strings"
+
+	"golang.org/x/sync/errgroup"
 
 	"passive-rec/internal/runner"
 )
 
-func GAU(ctx context.Context, target string, out chan<- string) error {
+func GAU(ctx context.Context, targets []string, out chan<- string) error {
+	if len(targets) == 0 {
+		return nil
+	}
 	bin, ok := runner.FindBin("gau", "getallurls")
 	if !ok {
 		out <- "meta: gau/getallurls not found in PATH"
 		return runner.ErrMissingBinary
 	}
-	return runner.RunCommand(ctx, bin, []string{target}, out)
+
+	group, groupCtx := errgroup.WithContext(ctx)
+	concurrency := runtime.NumCPU()
+	if concurrency <= 0 {
+		concurrency = 1
+	}
+	sem := make(chan struct{}, concurrency)
+
+	scheduled := false
+	for _, raw := range targets {
+		target := strings.TrimSpace(raw)
+		if target == "" {
+			continue
+		}
+		scheduled = true
+		current := target
+		group.Go(func() error {
+			select {
+			case sem <- struct{}{}:
+			case <-groupCtx.Done():
+				return groupCtx.Err()
+			}
+			defer func() { <-sem }()
+			return runner.RunCommand(groupCtx, bin, []string{current}, out)
+		})
+	}
+
+	if !scheduled {
+		return nil
+	}
+
+	if err := group.Wait(); err != nil {
+		return err
+	}
+	return nil
 
 }

--- a/internal/sources/httpx.go
+++ b/internal/sources/httpx.go
@@ -350,7 +350,13 @@ func shouldForwardHTTPXRoute(hasStatus bool, status int) bool {
 	if !hasStatus {
 		return true
 	}
-	return status != 0
+	if status == 0 {
+		return false
+	}
+	if status == 404 {
+		return false
+	}
+	return true
 }
 
 func shouldEmitHTTPXDomain(hasStatus bool, status int) bool {

--- a/internal/sources/httpx_test.go
+++ b/internal/sources/httpx_test.go
@@ -349,7 +349,6 @@ func TestHTTPXSkipsHTMLForErrorResponses(t *testing.T) {
 	}
 
 	want := []string{
-		"active: https://missing.example.com [404] [Not Found] [text/html]",
 		"active: missing.example.com [404] [Not Found] [text/html]",
 		"active: meta: [404]",
 		"active: meta: [Not Found]",

--- a/internal/sources/wayback.go
+++ b/internal/sources/wayback.go
@@ -2,14 +2,55 @@ package sources
 
 import (
 	"context"
+	"runtime"
+	"strings"
+
+	"golang.org/x/sync/errgroup"
 
 	"passive-rec/internal/runner"
 )
 
-func Wayback(ctx context.Context, target string, out chan<- string) error {
+func Wayback(ctx context.Context, targets []string, out chan<- string) error {
+	if len(targets) == 0 {
+		return nil
+	}
 	if !runner.HasBin("waybackurls") {
 		out <- "meta: waybackurls not found in PATH"
 		return runner.ErrMissingBinary
 	}
-	return runner.RunCommand(ctx, "waybackurls", []string{target}, out)
+
+	group, groupCtx := errgroup.WithContext(ctx)
+	concurrency := runtime.NumCPU()
+	if concurrency <= 0 {
+		concurrency = 1
+	}
+	sem := make(chan struct{}, concurrency)
+
+	scheduled := false
+	for _, raw := range targets {
+		target := strings.TrimSpace(raw)
+		if target == "" {
+			continue
+		}
+		scheduled = true
+		current := target
+		group.Go(func() error {
+			select {
+			case sem <- struct{}{}:
+			case <-groupCtx.Done():
+				return groupCtx.Err()
+			}
+			defer func() { <-sem }()
+			return runner.RunCommand(groupCtx, "waybackurls", []string{current}, out)
+		})
+	}
+
+	if !scheduled {
+		return nil
+	}
+
+	if err := group.Wait(); err != nil {
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
## Summary
- reorder the pipeline execution flow to stage discovery, deduplication, historical lookups, and active tooling with better progress handling
- add a deduplication helper that writes domains.dedupe, skip empty results, and exercise it in unit tests
- run waybackurls/gau over the deduped host list in parallel, adjust defaults to include the new stage, and skip httpx routes that return 404

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e1508227d083298c69535b05ebc188