### PR TITLE
Run active amass enumeration when requested

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -143,7 +143,7 @@ func Run(cfg *config.Config) error {
 	}
 
 	runSequential("amass", func(c context.Context) error {
-		return sourceAmass(c, cfg.Target, sink.In())
+		return sourceAmass(c, cfg.Target, sink.In(), cfg.Active)
 	})
 
 	runConcurrent([]string{"subfinder", "assetfinder"}, func(name string) func(context.Context) error {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -93,7 +93,7 @@ func ParseFlags() *Config {
 	target := flag.String("target", "", "Target domain (ej: example.com)")
 	outdir := flag.String("outdir", ".", "Directorio de salida (default: .)")
 	workers := flag.Int("workers", 6, "Número de workers")
-	active := flag.Bool("active", false, "Comprobaciones superficiales activas (httpx)")
+	active := flag.Bool("active", false, "Comprobaciones activas adicionales (amass/httpx)")
 	tools := flag.String("tools", "amass,subfinder,assetfinder,crtsh,dedupe,waybackurls,gau,httpx,subjs", "Herramientas, CSV")
 	timeout := flag.Int("timeout", 120, "Timeout por herramienta (segundos)")
 	verbosity := flag.Int("v", 0, "Verbosity (0=silent,1=info,2=debug,3=trace)")

--- a/internal/sources/amass.go
+++ b/internal/sources/amass.go
@@ -2,14 +2,32 @@ package sources
 
 import (
 	"context"
+	"errors"
 
 	"passive-rec/internal/runner"
 )
 
-func Amass(ctx context.Context, target string, out chan<- string) error {
+func Amass(ctx context.Context, target string, out chan<- string, active bool) error {
 	if !runner.HasBin("amass") {
 		out <- "meta: amass not found in PATH"
 		return runner.ErrMissingBinary
 	}
-	return runner.RunCommand(ctx, "amass", []string{"enum", "-passive", "-d", target}, out)
+
+	passiveArgs := []string{"enum", "-passive", "-d", target}
+	passiveErr := runner.RunCommand(ctx, "amass", passiveArgs, out)
+	if !active {
+		return passiveErr
+	}
+
+	activeArgs := []string{"enum", "-d", target}
+	activeErr := runner.RunCommand(ctx, "amass", activeArgs, out)
+
+	switch {
+	case passiveErr == nil:
+		return activeErr
+	case activeErr == nil:
+		return passiveErr
+	default:
+		return errors.Join(passiveErr, activeErr)
+	}
 }


### PR DESCRIPTION
## Summary
- pass cfg.Active into the Amass source so it can run in active mode
- execute both passive and active amass enumerations and combine their output
- clarify the CLI help string to mention amass in the active mode description

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e156958a108329b21d5791fd3085fd