### PR TITLE
Add domain handler to pipeline

### DIFF
--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -442,10 +442,21 @@ func handleCert(s *Sink, line string, isActive bool) bool {
 		return true
 	}
 
-	// defecto: dominio
-	key := netutil.NormalizeDomain(l)
+	return false
+}
+
+func handleDomain(s *Sink, line string, isActive bool) bool {
+	key := netutil.NormalizeDomain(line)
 	if key == "" {
 		return false
+	}
+
+	if isActive {
+		if !s.markSeen(s.seenDomainsPassive, key) {
+			if s.Domains.passive != nil {
+				_ = s.Domains.passive.WriteDomain(key)
+			}
+		}
 	}
 
 	seen := s.seenDomainsPassive


### PR DESCRIPTION
## Summary
- ensure certificate handler only processes certificate-prefixed lines
- add a dedicated domain handler that normalizes input and writes to the appropriate sinks

## Testing
- go test ./... *(fails: existing compilation errors in internal/app/app.go complaining about undefined ctx and sink.In signature)*

------
https://chatgpt.com/codex/tasks/task_e_68e15b236ef08329bd25f6b467d117ff