### PR TITLE
Refactor default tool pipeline ordering

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -103,17 +103,14 @@ func normalizeRequestedTools(cfg *config.Config) (map[string]bool, []string, []s
 		requested["dedupe"] = true
 	}
 
-	known := map[string]struct{}{
-		"amass": {}, "subfinder": {}, "assetfinder": {}, "crtsh": {},
-		"censys": {}, "dedupe": {}, "waybackurls": {}, "gau": {},
-		"httpx": {}, "subjs": {},
+	known := make(map[string]struct{}, len(defaultToolOrder))
+	for _, tool := range defaultToolOrder {
+		known[tool] = struct{}{}
 	}
-
-	pipelineOrder := []string{"amass", "subfinder", "assetfinder", "crtsh", "censys", "dedupe", "waybackurls", "gau", "httpx", "subjs"}
 
 	var ordered []string
 	seenOrdered := make(map[string]bool)
-	for _, tool := range pipelineOrder {
+	for _, tool := range defaultToolOrder {
 		if requested[tool] {
 			ordered = append(ordered, tool)
 			seenOrdered[tool] = true

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -54,7 +54,7 @@ func TestNormalizeRequestedToolsAddsDedupeAndOrders(t *testing.T) {
 		t.Fatalf("expected dedupe to be added when gau/waybackurls are requested")
 	}
 
-	wantOrdered := []string{"subfinder", "dedupe", "waybackurls", "gau", "custom"}
+	wantOrdered := append(selectFromOrder(defaultToolOrder, "subfinder", "dedupe", "waybackurls", "gau"), "custom")
 	if diff := cmp.Diff(wantOrdered, ordered); diff != "" {
 		t.Fatalf("unexpected ordered tools (-want +got):\n%s", diff)
 	}
@@ -74,7 +74,7 @@ func TestNormalizeRequestedToolsTrimsAndDeduplicates(t *testing.T) {
 		t.Fatalf("expected no unknown tools, got %v", unknown)
 	}
 
-	wantOrdered := []string{"amass", "httpx", "subjs"}
+	wantOrdered := selectFromOrder(defaultToolOrder, "amass", "httpx", "subjs")
 	if diff := cmp.Diff(wantOrdered, ordered); diff != "" {
 		t.Fatalf("unexpected ordered tools (-want +got):\n%s", diff)
 	}
@@ -82,6 +82,20 @@ func TestNormalizeRequestedToolsTrimsAndDeduplicates(t *testing.T) {
 	if !requested["amass"] || !requested["httpx"] || !requested["subjs"] {
 		t.Fatalf("expected requested map to include normalized tool names, got %v", requested)
 	}
+}
+
+func selectFromOrder(order []string, names ...string) []string {
+	include := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		include[name] = struct{}{}
+	}
+	var result []string
+	for _, tool := range order {
+		if _, ok := include[tool]; ok {
+			result = append(result, tool)
+		}
+	}
+	return result
 }
 
 func TestRunFlushesBeforeReportForDeferredSources(t *testing.T) {


### PR DESCRIPTION
## Summary
- derive the default tool step map from a single ordered pipeline definition
- reuse the canonical tool order when normalizing requested tools to remove duplicated lists
- update unit tests to rely on the shared canonical order helper

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e1601b332483299b75c79674ee4711