### PR TITLE
Use buffered writes for dedupe file generation

### DIFF
--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -192,6 +193,23 @@ func TestDedupeDomainListNormalizesAndFilters(t *testing.T) {
 	}
 	if diff := cmp.Diff(want, lines); diff != "" {
 		t.Fatalf("unexpected domains.dedupe contents (-want +got):\n%s", diff)
+	}
+}
+
+func TestDedupeDomainListWriteError(t *testing.T) {
+	dir := t.TempDir()
+	conflictPath := filepath.Join(dir, "domains", "domains.dedupe")
+	if err := os.MkdirAll(conflictPath, 0o755); err != nil {
+		t.Fatalf("mkdir conflicting path: %v", err)
+	}
+
+	if _, err := dedupeDomainList(dir); err == nil {
+		t.Fatalf("expected error when dedupe output path is a directory")
+	} else {
+		var pathErr *os.PathError
+		if !errors.As(err, &pathErr) {
+			t.Fatalf("expected *os.PathError, got %T", err)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- open the dedupe output file with `os.Create` and buffer domain writes to ensure flush errors surface
- add a regression test that exercises error handling when the dedupe output path cannot be created

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e16044ac18832994b68cd15647ed57