### PR TITLE
Filter non-domain output from scanners

### DIFF
--- a/internal/netutil/netutil.go
+++ b/internal/netutil/netutil.go
@@ -75,5 +75,9 @@ func NormalizeDomain(line string) string {
 		return ""
 	}
 
+	if net.ParseIP(lowered) == nil && !strings.Contains(lowered, ".") {
+		return ""
+	}
+
 	return lowered
 }

--- a/internal/netutil/netutil_test.go
+++ b/internal/netutil/netutil_test.go
@@ -24,6 +24,8 @@ func TestNormalizeDomain(t *testing.T) {
 		"http://example.com/path/to/page":                       "example.com",
 		"https://example.com?query=1":                           "example.com",
 		"http://[2001:db8::1]/path":                             "2001:db8::1",
+		"No results found":                                      "",
+		"NO":                                                    "",
 	}
 
 	for input, want := range tests {

--- a/internal/out/writer.go
+++ b/internal/out/writer.go
@@ -56,6 +56,10 @@ func normalizeDomain(d string) string {
 		lower = lower[4:]
 	}
 
+	if net.ParseIP(lower) == nil && !strings.Contains(lower, ".") {
+		return ""
+	}
+
 	if meta != "" {
 		return lower + " " + meta
 	}

--- a/internal/out/writer_test.go
+++ b/internal/out/writer_test.go
@@ -23,6 +23,7 @@ func TestNormalizeDomain(t *testing.T) {
 		" 2001:db8::1 ":                      "2001:db8::1",
 		"[2001:db8::1]:8443 status: up":      "2001:db8::1 status: up",
 		"":                                   "",
+		"No assets were discovered":          "",
 	}
 	for input, expected := range cases {
 		input, expected := input, expected
@@ -93,6 +94,7 @@ func TestWriteDomain(t *testing.T) {
 		"[2001:db8::1]:8443 status: up", // IPv6 with metadata
 		"2001:db8::1 status: up",        // duplicate preserving metadata
 		"",                              // ignored
+		"No assets were discovered",     // noise from assetfinder output
 	}
 	for _, in := range inputs {
 		if err := w.WriteDomain(in); err != nil {


### PR DESCRIPTION
## Summary
- skip non-domain tokens when normalizing sink input so tool status messages are not enqueued as targets
- drop noise without dots/IPs in the output writer and cover the behavior with unit tests

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e1619b4998832997495f89404e8346