### PR TITLE
Add certificate domain extraction to pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The same configuration in JSON:
 
 ## Censys certificates integration
 
-The `censys` source consumes the [Censys Search API](https://search.censys.io/api) to enumerate hosts from the certificate corpus. You must supply your account credentials through the new flags or environment variables:
+The `censys` source consumes the [Censys Search API](https://search.censys.io/api) to enumerate hosts from the certificate corpus. When certificate records are ingested their common name and SAN entries are now added to the domain artifacts, feeding both the passive list (and the active list when running in active mode). You must supply your account credentials through the new flags or environment variables:
 
 ```bash
 passive-rec --tools censys --censys-api-id "$CENSYS_API_ID" --censys-api-secret "$CENSYS_API_SECRET"

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -634,6 +634,25 @@ func (s *Sink) writeCertLine(line string) {
 		return
 	}
 
+	for _, name := range record.AllNames() {
+		domain := netutil.NormalizeDomain(name)
+		if domain == "" {
+			continue
+		}
+		if !s.markSeen(s.seenDomainsPassive, domain) {
+			if s.Domains.passive != nil {
+				_ = s.Domains.passive.WriteDomain(domain)
+			}
+		}
+		if s.activeMode {
+			if !s.markSeen(s.seenDomainsActive, domain) {
+				if s.Domains.active != nil {
+					_ = s.Domains.active.WriteDomain(domain)
+				}
+			}
+		}
+	}
+
 	key := record.Key()
 	if key == "" {
 		key = strings.ToLower(serialized)


### PR DESCRIPTION
## Summary
- ensure certificate processing adds SAN/common name entries into the domains artifacts, respecting passive and active modes
- extend pipeline tests to cover domain population from certificate lines and update expectations
- document that certificate ingestion now enriches the enumerated domain lists

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e16be3b6a48329abaf0c1a9eab3792