### PR TITLE
Refactor pipeline category writers to handle active and passive outputs

### DIFF
--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -519,6 +519,11 @@ func TestRouteCategorizationActiveMode(t *testing.T) {
 		t.Fatalf("Close: %v", err)
 	}
 
+	mapsPassive := readLines(t, filepath.Join(dir, "routes", "maps", "maps.passive"))
+	if diff := cmp.Diff([]string{"https://app.example.com/static/app.js.map"}, mapsPassive); diff != "" {
+		t.Fatalf("unexpected maps.passive contents (-want +got):\n%s", diff)
+	}
+
 	mapsPath := filepath.Join(dir, "routes", "maps", "maps.active")
 	mapsLines := readLines(t, mapsPath)
 	if diff := cmp.Diff([]string{"https://app.example.com/static/app.js.map"}, mapsLines); diff != "" {
@@ -528,6 +533,11 @@ func TestRouteCategorizationActiveMode(t *testing.T) {
 	jsonLines := readLines(t, filepath.Join(dir, "routes", "json", "json.active"))
 	if diff := cmp.Diff([]string{"https://app.example.com/static/manifest.json"}, jsonLines); diff != "" {
 		t.Fatalf("unexpected json.active contents (-want +got):\n%s", diff)
+	}
+
+	apiPassive := readLines(t, filepath.Join(dir, "routes", "api", "api.passive"))
+	if diff := cmp.Diff([]string{"https://app.example.com/static/swagger.json"}, apiPassive); diff != "" {
+		t.Fatalf("unexpected api.passive contents (-want +got):\n%s", diff)
 	}
 
 	apiLines := readLines(t, filepath.Join(dir, "routes", "api", "api.active"))
@@ -562,6 +572,32 @@ func TestRouteCategorizationActiveModeSkipsErrorStatus(t *testing.T) {
 	jsonPath := filepath.Join(dir, "routes", "json", "json.active")
 	if _, err := os.Stat(jsonPath); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("expected no json.active file, got err=%v", err)
+	}
+}
+
+func TestRouteCategorizationPassiveModeEmitsActiveFiles(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	sink, err := NewSink(dir, false)
+	if err != nil {
+		t.Fatalf("NewSink: %v", err)
+	}
+
+	sink.Start(1)
+	sink.In() <- "active: https://app.example.com/static/app.js.map [200]"
+
+	if err := sink.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	activeLines := readLines(t, filepath.Join(dir, "routes", "maps", "maps.active"))
+	if diff := cmp.Diff([]string{"https://app.example.com/static/app.js.map"}, activeLines); diff != "" {
+		t.Fatalf("unexpected maps.active contents (-want +got):\n%s", diff)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, "routes", "maps", "maps.passive")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected maps.passive to be absent, got err=%v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- replace single lazy writers for route categories with writer pairs that lazily emit passive and active data
- adjust sink lifecycle to initialize, select, and close both writers and update categorization logic to use active state keys
- expand pipeline tests to cover passive outputs in active mode and creation of active files when running in passive mode

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68e16c206b108329ad021994bf104c16