### PR TITLE
Filter error-status HTML active entries

### DIFF
--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -403,7 +403,22 @@ func handleHTML(s *Sink, line string, isActive bool) bool {
 		return true
 	}
 
-	if isImageURL(html) {
+	base := html
+	if isActive {
+		base = extractRouteBase(html)
+		if status, ok := parseActiveRouteStatus(html, base); ok {
+			if status <= 0 || status >= 400 {
+				return true
+			}
+		}
+	}
+
+	imageTarget := html
+	if base != "" {
+		imageTarget = base
+	}
+
+	if isImageURL(imageTarget) {
 		seen := s.seenHTMLImagesPassive
 		writer := s.RoutesImages.passive
 		if isActive {

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -454,6 +454,28 @@ func TestHTMLLinesAreWrittenToActiveFile(t *testing.T) {
 	}
 }
 
+func TestHTMLActiveSkipsErrorResponses(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	sink, err := NewSink(dir, false)
+	if err != nil {
+		t.Fatalf("NewSink: %v", err)
+	}
+
+	sink.Start(1)
+	sink.In() <- "active: html: https://app.example.com [404] [Not Found]"
+
+	if err := sink.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	htmlPath := filepath.Join(dir, "routes", "html", "html.active")
+	if lines := readLines(t, htmlPath); len(lines) != 0 {
+		t.Fatalf("expected html.active to be empty, got %v", lines)
+	}
+}
+
 func TestHTMLImageLinesAreRedirectedToImagesFile(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- skip writing active HTML entries when their HTTP status indicates an error
- normalize image classification for HTML lines that include extra metadata
- add a regression test ensuring html.active stays empty for 404 responses

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e171b9a8d88329983cfcd3836070aa