### PR TITLE
Refactor writer domain normalization

### DIFF
--- a/internal/out/writer.go
+++ b/internal/out/writer.go
@@ -1,12 +1,13 @@
 package out
 
 import (
-	"net"
 	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
+
+	"passive-rec/internal/netutil"
 )
 
 type Writer struct {
@@ -46,76 +47,15 @@ func normalizeDomain(d string) string {
 		d = strings.TrimSpace(d[:i])
 	}
 
-	host := extractHost(d)
-	if host == "" {
-		return ""
-	}
-
-	lower := strings.ToLower(host)
-	if strings.HasPrefix(lower, "www.") {
-		lower = lower[4:]
-	}
-
-	if net.ParseIP(lower) == nil && !strings.Contains(lower, ".") {
+	base := netutil.NormalizeDomain(d)
+	if base == "" {
 		return ""
 	}
 
 	if meta != "" {
-		return lower + " " + meta
+		return base + " " + meta
 	}
-	return lower
-}
-
-func extractHost(raw string) string {
-	if raw == "" {
-		return ""
-	}
-
-	candidate := raw
-	var parsed *url.URL
-	var err error
-
-	if strings.Contains(candidate, "://") {
-		parsed, err = url.Parse(candidate)
-	} else {
-		parsed, err = url.Parse("http://" + candidate)
-	}
-	if err == nil && parsed != nil {
-		hostPort := parsed.Host
-		hostname := parsed.Hostname()
-		if hostname != "" && !(strings.Count(hostPort, ":") > 1 && !strings.Contains(hostPort, "[")) {
-			return hostname
-		}
-		if hostPort != "" {
-			candidate = hostPort
-		}
-	}
-
-	if candidate == "" {
-		return ""
-	}
-
-	if at := strings.LastIndex(candidate, "@"); at != -1 {
-		candidate = candidate[at+1:]
-	}
-
-	if idx := strings.IndexAny(candidate, "/?#"); idx != -1 {
-		candidate = candidate[:idx]
-	}
-
-	if candidate == "" {
-		return ""
-	}
-
-	if host, _, err := net.SplitHostPort(candidate); err == nil {
-		return host
-	}
-
-	if strings.HasPrefix(candidate, "[") && strings.HasSuffix(candidate, "]") {
-		return strings.Trim(candidate, "[]")
-	}
-
-	return candidate
+	return base
 }
 
 func normalizeURL(u string) string {

--- a/internal/out/writer_test.go
+++ b/internal/out/writer_test.go
@@ -22,12 +22,19 @@ func TestNormalizeDomain(t *testing.T) {
 		"[2001:db8::1]:8443":                 "2001:db8::1",
 		" 2001:db8::1 ":                      "2001:db8::1",
 		"[2001:db8::1]:8443 status: up":      "2001:db8::1 status: up",
+		"example.com\tstatus:200":            "example.com status:200",
+		"example.com   status ok":            "example.com status ok",
+		"*.example.com":                      "",
 		"":                                   "",
 		"No assets were discovered":          "",
 	}
 	for input, expected := range cases {
 		input, expected := input, expected
-		t.Run(input, func(t *testing.T) {
+		name := strings.ReplaceAll(input, "\t", "\\t")
+		if name == "" {
+			name = "empty"
+		}
+		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			if got := normalizeDomain(input); got != expected {
 				t.Fatalf("normalizeDomain(%q) = %q, want %q", input, got, expected)


### PR DESCRIPTION
## Summary
- delegate domain normalization in the writer to `netutil.NormalizeDomain` while keeping metadata suffixes intact
- remove the redundant host extraction logic from the writer implementation
- expand writer tests to cover tabs, extra spaces, and wildcard inputs alongside existing cases

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e1732006a08329a786ca4b5503dde8