### PR TITLE
Integrate GoLinkfinderEVO into active pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ go run ./cmd/passive-rec -target example.com -outdir out -report
 
 The report is saved as `report.html` inside the selected output directory.
 
+When the `--active` flag is enabled the pipeline now includes [GoLinkfinderEVO](https://github.com/lcalzada-xor/GoLinkfinderEVO).
+The tool inspects the active HTML, JavaScript and crawl lists, stores consolidated reports under `routes/findings/` (raw, HTML and JSON formats) and feeds the discovered endpoints back into the categorised `.active` artifacts.
+
 ### Configuration file
 
 You can pre-populate the CLI flags with a YAML or JSON configuration file by passing its path through `--config`:

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -26,16 +26,17 @@ var (
 	sinkFactory = func(outdir string, active bool) (sink, error) {
 		return pipeline.NewSink(outdir, active)
 	}
-	sourceSubfinder   = sources.Subfinder
-	sourceAssetfinder = sources.Assetfinder
-	sourceAmass       = sources.Amass
-	sourceWayback     = sources.Wayback
-	sourceGAU         = sources.GAU
-	sourceCRTSh       = sources.CRTSH
-	sourceCensys      = sources.Censys
-	sourceHTTPX       = sources.HTTPX
-	sourceSubJS       = sources.SubJS
-	sourceDNSX        = sources.DNSX
+	sourceSubfinder     = sources.Subfinder
+	sourceAssetfinder   = sources.Assetfinder
+	sourceAmass         = sources.Amass
+	sourceWayback       = sources.Wayback
+	sourceGAU           = sources.GAU
+	sourceCRTSh         = sources.CRTSH
+	sourceCensys        = sources.Censys
+	sourceHTTPX         = sources.HTTPX
+	sourceSubJS         = sources.SubJS
+	sourceLinkFinderEVO = sources.LinkFinderEVO
+	sourceDNSX          = sources.DNSX
 )
 
 func Run(cfg *config.Config) error {

--- a/internal/app/orchestrator.go
+++ b/internal/app/orchestrator.go
@@ -79,6 +79,12 @@ var defaultPipeline = []toolStep{
 		RequiresActive:      true,
 		SkipInactiveMessage: "meta: subjs skipped (requires --active)",
 	},
+	{
+		Name:                "linkfinderevo",
+		Run:                 stepLinkFinderEVO,
+		RequiresActive:      true,
+		SkipInactiveMessage: "meta: linkfinderevo skipped (requires --active)",
+	},
 }
 
 var (
@@ -331,6 +337,10 @@ func timeoutHTTPX(state *pipelineState, opts orchestratorOptions) int {
 
 func stepSubJS(ctx context.Context, _ *pipelineState, opts orchestratorOptions) error {
 	return sourceSubJS(ctx, filepath.Join("routes", "routes.active"), opts.cfg.OutDir, opts.sink.In())
+}
+
+func stepLinkFinderEVO(ctx context.Context, _ *pipelineState, opts orchestratorOptions) error {
+	return sourceLinkFinderEVO(ctx, opts.cfg.Target, opts.cfg.OutDir, opts.sink.In())
 }
 
 func executePostProcessing(ctx context.Context, cfg *config.Config, sink sink, bar *progressBar, unknown []string) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -94,7 +94,7 @@ func ParseFlags() *Config {
 	outdir := flag.String("outdir", ".", "Directorio de salida (default: .)")
 	workers := flag.Int("workers", 6, "Número de workers")
 	active := flag.Bool("active", false, "Comprobaciones activas adicionales (amass/httpx)")
-	tools := flag.String("tools", "amass,subfinder,assetfinder,crtsh,dedupe,waybackurls,gau,httpx,subjs", "Herramientas, CSV")
+	tools := flag.String("tools", "amass,subfinder,assetfinder,crtsh,dedupe,waybackurls,gau,httpx,subjs,linkfinderevo", "Herramientas, CSV")
 	timeout := flag.Int("timeout", 120, "Timeout por herramienta (segundos)")
 	verbosity := flag.Int("v", 0, "Verbosity (0=silent,1=info,2=debug,3=trace)")
 	report := flag.Bool("report", false, "Generar un informe HTML al finalizar")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -34,7 +34,7 @@ func TestParseFlagsDefaults(t *testing.T) {
 		t.Fatalf("expected default outdir '.', got %q", cfg.OutDir)
 	}
 
-	expectedTools := []string{"amass", "subfinder", "assetfinder", "crtsh", "dedupe", "waybackurls", "gau", "httpx", "subjs"}
+	expectedTools := []string{"amass", "subfinder", "assetfinder", "crtsh", "dedupe", "waybackurls", "gau", "httpx", "subjs", "linkfinderevo"}
 	if !reflect.DeepEqual(cfg.Tools, expectedTools) {
 		t.Fatalf("expected default tools %v, got %v", expectedTools, cfg.Tools)
 	}

--- a/internal/sources/linkfinderevo_test.go
+++ b/internal/sources/linkfinderevo_test.go
@@ -1,0 +1,51 @@
+package sources
+
+import "testing"
+
+func TestClassifyLinkfinderEndpoint(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		wantJS     bool
+		wantHTML   bool
+		undetected bool
+	}{
+		{name: "javascript absolute", input: "https://example.com/app/main.js", wantJS: true},
+		{name: "html absolute", input: "https://example.com/index.html", wantHTML: true},
+		{name: "relative path", input: "api/v1/users", undetected: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := classifyLinkfinderEndpoint(tt.input)
+			if got.isJS != tt.wantJS {
+				t.Fatalf("isJS mismatch: got %v want %v", got.isJS, tt.wantJS)
+			}
+			if got.isHTML != tt.wantHTML {
+				t.Fatalf("isHTML mismatch: got %v want %v", got.isHTML, tt.wantHTML)
+			}
+			if got.undetected != tt.undetected {
+				t.Fatalf("undetected mismatch: got %v want %v", got.undetected, tt.undetected)
+			}
+		})
+	}
+}
+
+func TestNormalizeScope(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{input: "example.com", want: "example.com"},
+		{input: "https://sub.example.com", want: "sub.example.com"},
+		{input: "", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := normalizeScope(tt.input); got != tt.want {
+				t.Fatalf("normalizeScope(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ gau github.com/lc/gau/v2/cmd/gau@latest
 httpx github.com/projectdiscovery/httpx/cmd/httpx@latest
 subfinder github.com/projectdiscovery/subfinder/v2/cmd/subfinder@latest
 waybackurls github.com/tomnomnom/waybackurls@latest
+GoLinkfinderEVO github.com/example/GoLinkfinderEVO@latest


### PR DESCRIPTION
## Summary
- add a LinkFinder EVO active source that runs the binary on generated HTML/JS/crawl lists, consolidates outputs under `routes/findings`, and re-emits categorised endpoints
- register the new tool in the orchestrator defaults, configuration defaults, requirements, and documentation
- cover helper logic with focused unit tests

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e2752232d88329805a90e9ff19759e