### PR TITLE
Fix GoLinkfinderEVO module path

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ gau github.com/lc/gau/v2/cmd/gau@latest
 httpx github.com/projectdiscovery/httpx/cmd/httpx@latest
 subfinder github.com/projectdiscovery/subfinder/v2/cmd/subfinder@latest
 waybackurls github.com/tomnomnom/waybackurls@latest
-GoLinkfinderEVO github.com/example/GoLinkfinderEVO@latest
+GoLinkfinderEVO github.com/lcalzada-xor/GoLinkfinderEVO@latest


### PR DESCRIPTION
## Summary
- update the GoLinkfinderEVO dependency to reference the correct repository

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e27979d2488329a68726ae30617dd6