### PR TITLE
Filter sink outputs to audit scope

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -23,8 +23,8 @@ type sink interface {
 }
 
 var (
-	sinkFactory = func(outdir string, active bool) (sink, error) {
-		return pipeline.NewSink(outdir, active)
+	sinkFactory = func(outdir string, active bool, target string) (sink, error) {
+		return pipeline.NewSink(outdir, active, target)
 	}
 	sourceSubfinder     = sources.Subfinder
 	sourceAssetfinder   = sources.Assetfinder
@@ -46,7 +46,7 @@ func Run(cfg *config.Config) error {
 	}
 	cfg.OutDir = outDir
 
-	sink, err := sinkFactory(cfg.OutDir, cfg.Active)
+	sink, err := sinkFactory(cfg.OutDir, cfg.Active, cfg.Target)
 	if err != nil {
 		return err
 	}

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -115,7 +115,7 @@ func TestRunFlushesBeforeReportForDeferredSources(t *testing.T) {
 		flushes int
 	)
 
-	sinkFactory = func(outdir string, active bool) (sink, error) {
+	sinkFactory = func(outdir string, active bool, target string) (sink, error) {
 		ts, err := newTestSink(outdir)
 		if err != nil {
 			return nil, err

--- a/internal/app/orchestrator_test.go
+++ b/internal/app/orchestrator_test.go
@@ -115,7 +115,7 @@ func TestRunPipelineConcurrentGroupProgress(t *testing.T) {
 func TestRunPipelineConcurrentSourcesDedupesSink(t *testing.T) {
 	dir := t.TempDir()
 
-	sink, err := pipeline.NewSink(dir, true)
+	sink, err := pipeline.NewSink(dir, true, "example.com")
 	if err != nil {
 		t.Fatalf("NewSink: %v", err)
 	}

--- a/internal/netutil/scope.go
+++ b/internal/netutil/scope.go
@@ -1,0 +1,126 @@
+package netutil
+
+import (
+	"net"
+	"net/url"
+	"strings"
+
+	"golang.org/x/net/publicsuffix"
+)
+
+// Scope represents the canonical domain boundaries for a scan.
+type Scope struct {
+	hostname    string
+	registrable string
+	ip          net.IP
+}
+
+// NewScope builds a Scope from the provided target. If the target cannot
+// be normalised into a domain the returned scope is nil and no filtering
+// will be enforced.
+func NewScope(target string) *Scope {
+	normalized := NormalizeDomain(target)
+	if normalized == "" {
+		return nil
+	}
+
+	if ip := net.ParseIP(normalized); ip != nil {
+		return &Scope{hostname: normalized, ip: ip}
+	}
+
+	registrable := normalized
+	if effective, err := publicsuffix.EffectiveTLDPlusOne(normalized); err == nil && effective != "" {
+		registrable = strings.ToLower(effective)
+	}
+
+	return &Scope{
+		hostname:    normalized,
+		registrable: registrable,
+	}
+}
+
+// AllowsDomain reports whether the provided domain falls within the
+// configured scope. Domains outside of scope are rejected.
+func (s *Scope) AllowsDomain(candidate string) bool {
+	if s == nil {
+		return true
+	}
+
+	normalized := NormalizeDomain(candidate)
+	if normalized == "" {
+		return false
+	}
+
+	if s.ip != nil {
+		if net.ParseIP(normalized) == nil {
+			return false
+		}
+		return normalized == s.hostname
+	}
+
+	if net.ParseIP(normalized) != nil {
+		return false
+	}
+
+	if s.registrable == "" {
+		return normalized == s.hostname
+	}
+
+	if normalized == s.hostname || normalized == s.registrable {
+		return true
+	}
+
+	return strings.HasSuffix(normalized, "."+s.registrable)
+}
+
+// AllowsRoute reports whether the route belongs to the configured scope.
+// Relative paths (no host) are always allowed. When the route contains a
+// host, it must fall inside the scope boundaries.
+func (s *Scope) AllowsRoute(route string) bool {
+	if s == nil {
+		return true
+	}
+
+	trimmed := strings.TrimSpace(route)
+	if trimmed == "" {
+		return false
+	}
+
+	if strings.HasPrefix(trimmed, "//") {
+		if parsed, err := url.Parse("http:" + trimmed); err == nil {
+			if host := parsed.Hostname(); host != "" {
+				return s.AllowsDomain(host)
+			}
+		}
+		host := strings.TrimPrefix(trimmed, "//")
+		return s.AllowsDomain(host)
+	}
+
+	// Relative paths or fragments lack host information and are assumed to
+	// belong to the current scope.
+	switch trimmed[0] {
+	case '/', '.', '#', '?':
+		return true
+	}
+
+	if !strings.Contains(trimmed, "://") && !strings.HasPrefix(trimmed, "//") {
+		// Non-schemed values (like bare domains) are treated as domains.
+		return s.AllowsDomain(trimmed)
+	}
+
+	parsed, err := url.Parse(trimmed)
+	if err != nil {
+		// Fall back to domain validation using the best-effort host guess.
+		host := trimmed
+		if idx := strings.Index(trimmed, "/"); idx != -1 {
+			host = trimmed[:idx]
+		}
+		return s.AllowsDomain(host)
+	}
+
+	host := parsed.Hostname()
+	if host == "" {
+		return true
+	}
+	return s.AllowsDomain(host)
+}

--- a/internal/sources/httpx_test.go
+++ b/internal/sources/httpx_test.go
@@ -373,7 +373,7 @@ func TestHTTPXNormalizesOutput(t *testing.T) {
 	}
 
 	outputDir := t.TempDir()
-	sink, err := pipeline.NewSink(outputDir, false)
+	sink, err := pipeline.NewSink(outputDir, false, "example.com")
 	if err != nil {
 		t.Fatalf("new sink: %v", err)
 	}


### PR DESCRIPTION
## Summary
- add a netutil scope helper to canonicalise the target and validate domains and routes
- update the pipeline sink to filter domains, routes, and certificates so only in-scope evidence is retained
- wire the target through the application and extend tests to cover the new filtering behaviour

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e27d7866988329acce43330fb4996e