### PR TITLE
Handle partial LinkFinderEVO outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ go run ./cmd/passive-rec -target example.com -proxy http://127.0.0.1:8080
 The value is used to populate the standard `HTTP(S)_PROXY` environment variables before invoking the pipeline.
 
 When the `--active` flag is enabled the pipeline now includes [GoLinkfinderEVO](https://github.com/lcalzada-xor/GoLinkfinderEVO).
-The tool inspects the active HTML, JavaScript and crawl lists, stores consolidated reports under `routes/findings/` (raw, HTML and JSON formats) and feeds the discovered endpoints back into the categorised `.active` artifacts.
+The tool inspects the active HTML, JavaScript and crawl lists, stores consolidated reports under `routes/linkFindings/` (`findings.json`, `findings.html` and `findings.raw`) and feeds the discovered endpoints back into the categorised `.active` artifacts.
 
 ### Configuration file
 


### PR DESCRIPTION
## Summary
- ensure LinkFinderEVO aggregates and writes findings even when the tool exits early
- store GoLinkfinderEVO artifacts under routes/linkFindings/ with a .raw export
- document the new output location in the README

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e28cb9d20883299a07ed1e8d31750a