### PR TITLE
Add proxy CA support for proxied TLS traffic

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,13 @@ If you need to route all outbound HTTP/S requests (including third-party tools) 
 go run ./cmd/passive-rec -target example.com -proxy http://127.0.0.1:8080
 ```
 
-The value is used to populate the standard `HTTP(S)_PROXY` environment variables before invoking the pipeline.
+The value is used to populate the standard `HTTP(S)_PROXY` environment variables before invoking the pipeline. When your proxy
+performs TLS interception with its own certificate authority (for example Burp Suite or OWASP ZAP), point `-proxy-ca` to the
+PEM file containing that certificate so passive-rec trusts the man-in-the-middle tunnel:
+
+```
+go run ./cmd/passive-rec -target example.com -proxy http://127.0.0.1:8080 -proxy-ca ~/.config/burp/ca-cert.pem
+```
 
 When the `--active` flag is enabled the pipeline now includes [GoLinkfinderEVO](https://github.com/lcalzada-xor/GoLinkfinderEVO).
 The tool inspects the active HTML, JavaScript and crawl lists, stores consolidated reports under `routes/linkFindings/` (`findings.json`, `findings.html` and `findings.raw`) and feeds the discovered endpoints back into the categorised `.active` artifacts.
@@ -61,6 +67,7 @@ If a value is present both in the config file and as a CLI flag, the CLI flag wi
 | `verbosity`        | int                 | Nivel de verbosidad (0-3)                        |
 | `report`           | bool                | Genera informe HTML                              |
 | `proxy`            | string              | URL del proxy HTTP/HTTPS                         |
+| `proxy_ca`         | string              | Ruta a un certificado CA adicional para el proxy |
 | `censys_api_id`    | string              | Credencial Censys API ID                         |
 | `censys_api_secret`| string              | Credencial Censys API Secret                     |
 
@@ -78,6 +85,7 @@ timeout: 180
 verbosity: 1
 report: true
 proxy: http://127.0.0.1:8080
+proxy_ca: ~/.config/burp/ca-cert.pem
 censys_api_id: "${CENSYS_API_ID}"
 censys_api_secret: "${CENSYS_API_SECRET}"
 ```
@@ -95,6 +103,7 @@ The same configuration in JSON:
   "verbosity": 1,
   "report": true,
   "proxy": "http://127.0.0.1:8080",
+  "proxy_ca": "~/.config/burp/ca-cert.pem",
   "censys_api_id": "${CENSYS_API_ID}",
   "censys_api_secret": "${CENSYS_API_SECRET}"
 }

--- a/cmd/passive-rec/main.go
+++ b/cmd/passive-rec/main.go
@@ -21,6 +21,13 @@ func main() {
 	if cfg.Proxy != "" {
 		logx.Infof("Usando proxy %s", cfg.Proxy)
 	}
+	if err := config.ConfigureRootCAs(cfg.ProxyCACert); err != nil {
+		logx.Errorf("%v", err)
+		os.Exit(1)
+	}
+	if cfg.ProxyCACert != "" {
+		logx.Infof("Certificado CA adicional cargado desde %s", cfg.ProxyCACert)
+	}
 	logx.Infof("Iniciando passive-rec target=%s outdir=%s tools=%v workers=%d active=%v report=%v",
 		cfg.Target, cfg.OutDir, cfg.Tools, cfg.Workers, cfg.Active, cfg.Report)
 

--- a/internal/sources/subjs.go
+++ b/internal/sources/subjs.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"net/http"
@@ -14,6 +15,7 @@ import (
 	"sync"
 	"time"
 
+	"passive-rec/internal/config"
 	"passive-rec/internal/runner"
 )
 
@@ -27,6 +29,9 @@ var (
 		transport := &http.Transport{
 			Proxy:                 http.ProxyFromEnvironment,
 			ResponseHeaderTimeout: 10 * time.Second,
+		}
+		if pool := config.CustomRootCAs(); pool != nil {
+			transport.TLSClientConfig = &tls.Config{RootCAs: pool}
 		}
 		return &http.Client{Transport: transport, Timeout: subjsHTTPTimeout}
 	}


### PR DESCRIPTION
## Summary
- add a new `-proxy-ca`/`proxy_ca` option to load an extra certificate authority bundle
- wire the CA bundle into the default HTTP transport and SubJS client so TLS MITM proxies work
- document the new flag and cover the behaviour with unit tests

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e2cc9f0c008329aa16d3c4d1174aee