### PR TITLE
Preserve GoLinkfinderEVO per-source outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ go run ./cmd/passive-rec -target example.com -proxy http://127.0.0.1:8080 -proxy
 
 When the `--active` flag is enabled the pipeline now includes [GoLinkfinderEVO](https://github.com/lcalzada-xor/GoLinkfinderEVO).
 The tool inspects the active HTML, JavaScript and crawl lists, stores consolidated reports under `routes/linkFindings/` (`findings.json`, `findings.html` and `findings.raw`) and feeds the discovered endpoints back into the categorised `.active` artifacts.
+For reference, the raw GoLinkfinderEVO outputs from each input list are also preserved alongside the consolidated files as `findings.html.*`, `findings.js.*` and `findings.crawl.*`.
 
 ### Configuration file
 

--- a/internal/sources/linkfinderevo_test.go
+++ b/internal/sources/linkfinderevo_test.go
@@ -1,6 +1,12 @@
 package sources
 
-import "testing"
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
 
 func TestClassifyLinkfinderEndpoint(t *testing.T) {
 	tests := []struct {
@@ -47,5 +53,92 @@ func TestNormalizeScope(t *testing.T) {
 				t.Fatalf("normalizeScope(%q) = %q, want %q", tt.input, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestWriteLinkfinderOutputsCreatesAllFormats(t *testing.T) {
+	agg := newLinkfinderAggregate()
+	agg.add("https://example.com/index.html", linkfinderEndpoint{Link: "https://example.com/api", Context: "fetch('/api')", Line: 10})
+
+	tmp := t.TempDir()
+
+	out := make(chan string, 10)
+	if err := writeLinkfinderOutputs(tmp, agg, out); err != nil {
+		t.Fatalf("writeLinkfinderOutputs returned error: %v", err)
+	}
+
+	findingsDir := filepath.Join(tmp, "routes", "linkFindings")
+	files := []string{"findings.json", "findings.raw", "findings.html"}
+	for _, name := range files {
+		path := filepath.Join(findingsDir, name)
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("expected %s to be created: %v", name, err)
+		}
+	}
+}
+
+func TestLinkFinderEVOIntegrationGeneratesReports(t *testing.T) {
+	if _, err := os.Stat("/tmp/golinkfinder"); err != nil {
+		t.Skip("GoLinkfinderEVO binary not available for integration test")
+	}
+
+	prevFindBin := linkfinderFindBin
+	prevRunCmd := linkfinderRunCmd
+	t.Cleanup(func() {
+		linkfinderFindBin = prevFindBin
+		linkfinderRunCmd = prevRunCmd
+	})
+
+	linkfinderFindBin = func(names ...string) (string, bool) {
+		return "/tmp/golinkfinder", true
+	}
+
+	tmp := t.TempDir()
+	routesDir := filepath.Join(tmp, "routes")
+	if err := os.MkdirAll(filepath.Join(routesDir, "html"), 0o755); err != nil {
+		t.Fatalf("failed to create html dir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(routesDir, "js"), 0o755); err != nil {
+		t.Fatalf("failed to create js dir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(routesDir, "crawl"), 0o755); err != nil {
+		t.Fatalf("failed to create crawl dir: %v", err)
+	}
+
+	sample := filepath.Join(tmp, "sample.html")
+	if err := os.WriteFile(sample, []byte(`<html><body><script src="/static/app.js"></script><a href="/foo/bar.html">Link</a></body></html>`), 0o644); err != nil {
+		t.Fatalf("failed to write sample html: %v", err)
+	}
+
+	htmlList := filepath.Join(routesDir, "html", "html.active")
+	if err := os.WriteFile(htmlList, []byte("file://"+sample+"\n"), 0o644); err != nil {
+		t.Fatalf("failed to write html list: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(routesDir, "js", "js.active"), nil, 0o644); err != nil {
+		t.Fatalf("failed to write js list: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(routesDir, "crawl", "crawl.active"), nil, 0o644); err != nil {
+		t.Fatalf("failed to write crawl list: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	out := make(chan string, 10)
+	if err := LinkFinderEVO(ctx, "https://example.com", tmp, out); err != nil {
+		t.Fatalf("LinkFinderEVO returned error: %v", err)
+	}
+
+	findingsDir := filepath.Join(routesDir, "linkFindings")
+	for _, name := range []string{"findings.json", "findings.raw", "findings.html"} {
+		if _, err := os.Stat(filepath.Join(findingsDir, name)); err != nil {
+			t.Fatalf("expected %s to exist: %v", name, err)
+		}
+	}
+
+	for _, name := range []string{"findings.html.json", "findings.html.raw", "findings.html.html"} {
+		if _, err := os.Stat(filepath.Join(findingsDir, name)); err != nil {
+			t.Fatalf("expected intermediate artifact %s: %v", name, err)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- copy each GoLinkfinderEVO run's raw/json/html outputs into routes/linkFindings with a per-input suffix before they are overwritten
- clean up any per-input artifacts when no results are produced and document the new files in the README
- add tests (including an integration test when the binary is present) to cover the new output handling

## Testing
- go test ./... -count=1


------
https://chatgpt.com/codex/tasks/task_e_68e2cfa97f5c83298be8c7fdb59abaa0