### PR TITLE
Add passive HTML route sink writer

### DIFF
--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -206,6 +206,10 @@ func NewSink(outdir string, active bool, target string) (*Sink, error) {
 	if err != nil {
 		return nil, err
 	}
+	htmlPassive, err := newWriter(filepath.Join("routes", "html"), "html.passive")
+	if err != nil {
+		return nil, err
+	}
 	htmlActive, err := newWriter(filepath.Join("routes", "html"), "html.active")
 	if err != nil {
 		return nil, err
@@ -235,7 +239,7 @@ func NewSink(outdir string, active bool, target string) (*Sink, error) {
 		Domains:               writerPair{passive: dPassive, active: dActive},
 		Routes:                writerPair{passive: rPassive, active: rActive},
 		RoutesJS:              writerPair{passive: jsPassive, active: jsActive},
-		RoutesHTML:            writerPair{active: htmlActive},
+		RoutesHTML:            writerPair{passive: htmlPassive, active: htmlActive},
 		RoutesImages:          writerPair{active: imagesActive},
 		RoutesMaps:            writerPair{passive: newLazyWriter(outdir, filepath.Join("routes", "maps"), "maps.passive"), active: newLazyWriter(outdir, filepath.Join("routes", "maps"), "maps.active")},
 		RoutesJSON:            writerPair{passive: newLazyWriter(outdir, filepath.Join("routes", "json"), "json.passive"), active: newLazyWriter(outdir, filepath.Join("routes", "json"), "json.active")},

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -238,6 +238,11 @@ func TestSinkFiltersOutOfScope(t *testing.T) {
 		t.Fatalf("unexpected js.passive contents (-want +got):\n%s", diff)
 	}
 
+	htmlRoutes := read(filepath.Join(dir, "routes", "html", "html.passive"))
+	if diff := cmp.Diff([]string{"https://app.example.com/index.html"}, htmlRoutes); diff != "" {
+		t.Fatalf("unexpected html.passive contents (-want +got):\n%s", diff)
+	}
+
 	certsPassive := read(filepath.Join(dir, "certs", "certs.passive"))
 	if len(certsPassive) != 1 {
 		t.Fatalf("expected 1 certificate, got %v", certsPassive)


### PR DESCRIPTION
## Summary
- ensure the pipeline creates a passive HTML writer and wires it into the sink
- extend the pipeline tests to verify passive HTML output is written under routes/html

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e2da83be608329a96c2d478b1f3809