### PR TITLE
Sanitize GoLinkfinderEVO endpoint output

### DIFF
--- a/internal/sources/linkfinderevo.go
+++ b/internal/sources/linkfinderevo.go
@@ -67,7 +67,7 @@ func (agg *linkfinderAggregate) add(resource string, endpoint linkfinderEndpoint
 	if resource == "" {
 		return
 	}
-	endpoint.Link = strings.TrimSpace(endpoint.Link)
+	endpoint.Link = cleanLinkfinderEndpointLink(endpoint.Link)
 	if endpoint.Link == "" {
 		return
 	}
@@ -630,6 +630,23 @@ func writeLinkfinderUndetected(path string, entries []string) error {
 	}
 
 	return os.WriteFile(path, buf.Bytes(), 0o644)
+}
+
+func cleanLinkfinderEndpointLink(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return ""
+	}
+
+	trimmed = strings.Trim(trimmed, "\"'`")
+
+	if idx := strings.IndexAny(trimmed, " \t\r\n\"'<>[]{}()"); idx != -1 {
+		trimmed = trimmed[:idx]
+	}
+
+	trimmed = strings.TrimRight(trimmed, ",.;")
+
+	return strings.TrimSpace(trimmed)
 }
 
 const linkfinderTemplate = `<!DOCTYPE html>

--- a/internal/sources/linkfinderevo_test.go
+++ b/internal/sources/linkfinderevo_test.go
@@ -141,6 +141,28 @@ func TestWriteLinkfinderOutputsCreatesAllFormats(t *testing.T) {
 	}
 }
 
+func TestCleanLinkfinderEndpointLink(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "already clean", input: "https://example.com/app.js", want: "https://example.com/app.js"},
+		{name: "trailing script noise", input: "https://uvesa.es/})}else{visibilityCache=[]", want: "https://uvesa.es/"},
+		{name: "wrapped in quotes", input: "\"/static/app.js\"", want: "/static/app.js"},
+		{name: "with trailing punctuation", input: "https://example.com/api/v1/users,", want: "https://example.com/api/v1/users"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			if got := cleanLinkfinderEndpointLink(tt.input); got != tt.want {
+				t.Fatalf("cleanLinkfinderEndpointLink(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestLinkFinderEVOIntegrationGeneratesReports(t *testing.T) {
 	if _, err := os.Stat("/tmp/golinkfinder"); err != nil {
 		t.Skip("GoLinkfinderEVO binary not available for integration test")


### PR DESCRIPTION
## Summary
- sanitize GoLinkfinderEVO endpoint links before aggregation to drop residual script fragments
- add targeted unit tests covering the endpoint cleaning routine

## Testing
- go test ./internal/sources -run TestCleanLinkfinderEndpointLink -count=1 -v

------
https://chatgpt.com/codex/tasks/task_e_68e3e60260d88329a3893622f5d8292a