### PR TITLE
Optimize sink initialization and add handler metrics

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -23,8 +23,8 @@ type sink interface {
 }
 
 var (
-	sinkFactory = func(outdir string, active bool, target string) (sink, error) {
-		return pipeline.NewSink(outdir, active, target)
+	sinkFactory = func(outdir string, active bool, target string, lineBuffer int) (sink, error) {
+		return pipeline.NewSink(outdir, active, target, lineBuffer)
 	}
 	sourceSubfinder     = sources.Subfinder
 	sourceAssetfinder   = sources.Assetfinder
@@ -47,7 +47,7 @@ func Run(cfg *config.Config) error {
 	}
 	cfg.OutDir = outDir
 
-	sink, err := sinkFactory(cfg.OutDir, cfg.Active, cfg.Target)
+	sink, err := sinkFactory(cfg.OutDir, cfg.Active, cfg.Target, pipeline.LineBufferSize(cfg.Workers))
 	if err != nil {
 		return err
 	}

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -115,7 +115,7 @@ func TestRunFlushesBeforeReportForDeferredSources(t *testing.T) {
 		flushes int
 	)
 
-	sinkFactory = func(outdir string, active bool, target string) (sink, error) {
+	sinkFactory = func(outdir string, active bool, target string, lineBuffer int) (sink, error) {
 		ts, err := newTestSink(outdir)
 		if err != nil {
 			return nil, err

--- a/internal/app/orchestrator_test.go
+++ b/internal/app/orchestrator_test.go
@@ -115,7 +115,7 @@ func TestRunPipelineConcurrentGroupProgress(t *testing.T) {
 func TestRunPipelineConcurrentSourcesDedupesSink(t *testing.T) {
 	dir := t.TempDir()
 
-	sink, err := pipeline.NewSink(dir, true, "example.com")
+	sink, err := pipeline.NewSink(dir, true, "example.com", pipeline.LineBufferSize(4))
 	if err != nil {
 		t.Fatalf("NewSink: %v", err)
 	}

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -17,7 +17,7 @@ import (
 func newTestSink(t *testing.T, active bool) (*Sink, string) {
 	t.Helper()
 	dir := t.TempDir()
-	sink, err := NewSink(dir, active, "example.com")
+	sink, err := NewSink(dir, active, "example.com", LineBufferSize(1))
 	if err != nil {
 		t.Fatalf("NewSink: %v", err)
 	}
@@ -28,7 +28,7 @@ func TestSinkClassification(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	sink, err := NewSink(dir, false, "example.com")
+	sink, err := NewSink(dir, false, "example.com", LineBufferSize(1))
 	if err != nil {
 		t.Fatalf("NewSink: %v", err)
 	}
@@ -170,7 +170,7 @@ func TestSinkFiltersOutOfScope(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	sink, err := NewSink(dir, false, "example.com")
+	sink, err := NewSink(dir, false, "example.com", LineBufferSize(2))
 	if err != nil {
 		t.Fatalf("NewSink: %v", err)
 	}
@@ -327,7 +327,7 @@ func TestSinkFlush(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	sink, err := NewSink(dir, false, "example.com")
+	sink, err := NewSink(dir, false, "example.com", LineBufferSize(2))
 	if err != nil {
 		t.Fatalf("NewSink: %v", err)
 	}
@@ -395,7 +395,7 @@ func TestNewSinkClosesWritersOnError(t *testing.T) {
 		t.Fatalf("unexpected open descriptors before NewSink: %d", got)
 	}
 
-	sink, err := NewSink(dir, false, "example.com")
+	sink, err := NewSink(dir, false, "example.com", LineBufferSize(1))
 	if err == nil {
 		// Close to ensure no resources leak in this unexpected success case.
 		_ = sink.Close()
@@ -479,7 +479,7 @@ func TestActiveRoutesPopulatePassive(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	sink, err := NewSink(dir, false, "example.com")
+	sink, err := NewSink(dir, false, "example.com", LineBufferSize(1))
 	if err != nil {
 		t.Fatalf("NewSink: %v", err)
 	}
@@ -506,7 +506,7 @@ func TestActiveRoutesSkip404(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	sink, err := NewSink(dir, false, "example.com")
+	sink, err := NewSink(dir, false, "example.com", LineBufferSize(1))
 	if err != nil {
 		t.Fatalf("NewSink: %v", err)
 	}
@@ -538,7 +538,7 @@ func TestJSLinesAreWrittenToFile(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	sink, err := NewSink(dir, false, "example.com")
+	sink, err := NewSink(dir, false, "example.com", LineBufferSize(1))
 	if err != nil {
 		t.Fatalf("NewSink: %v", err)
 	}
@@ -568,7 +568,7 @@ func TestActiveJSExcludes404(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	sink, err := NewSink(dir, false, "example.com")
+	sink, err := NewSink(dir, false, "example.com", LineBufferSize(1))
 	if err != nil {
 		t.Fatalf("NewSink: %v", err)
 	}
@@ -592,7 +592,7 @@ func TestHTMLLinesAreWrittenToActiveFile(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	sink, err := NewSink(dir, false, "example.com")
+	sink, err := NewSink(dir, false, "example.com", LineBufferSize(1))
 	if err != nil {
 		t.Fatalf("NewSink: %v", err)
 	}
@@ -615,7 +615,7 @@ func TestHTMLActiveSkipsErrorResponses(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	sink, err := NewSink(dir, false, "example.com")
+	sink, err := NewSink(dir, false, "example.com", LineBufferSize(1))
 	if err != nil {
 		t.Fatalf("NewSink: %v", err)
 	}
@@ -637,7 +637,7 @@ func TestHTMLImageLinesAreRedirectedToImagesFile(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	sink, err := NewSink(dir, false, "example.com")
+	sink, err := NewSink(dir, false, "example.com", LineBufferSize(1))
 	if err != nil {
 		t.Fatalf("NewSink: %v", err)
 	}
@@ -670,7 +670,7 @@ func TestRouteCategorizationPassive(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	sink, err := NewSink(dir, false, "example.com")
+	sink, err := NewSink(dir, false, "example.com", LineBufferSize(1))
 	if err != nil {
 		t.Fatalf("NewSink: %v", err)
 	}
@@ -753,7 +753,7 @@ func TestRouteCategorizationActiveMode(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	sink, err := NewSink(dir, true, "example.com")
+	sink, err := NewSink(dir, true, "example.com", LineBufferSize(1))
 	if err != nil {
 		t.Fatalf("NewSink: %v", err)
 	}
@@ -807,7 +807,7 @@ func TestRouteCategorizationActiveModeSkipsErrorStatus(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	sink, err := NewSink(dir, true, "example.com")
+	sink, err := NewSink(dir, true, "example.com", LineBufferSize(1))
 	if err != nil {
 		t.Fatalf("NewSink: %v", err)
 	}
@@ -829,7 +829,7 @@ func TestRouteCategorizationPassiveModeEmitsActiveFiles(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	sink, err := NewSink(dir, false, "example.com")
+	sink, err := NewSink(dir, false, "example.com", LineBufferSize(1))
 	if err != nil {
 		t.Fatalf("NewSink: %v", err)
 	}
@@ -855,7 +855,7 @@ func TestRouteCategorizationDeduplicatesCategoryOutputs(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	sink, err := NewSink(dir, false, "example.com")
+	sink, err := NewSink(dir, false, "example.com", LineBufferSize(2))
 	if err != nil {
 		t.Fatalf("NewSink: %v", err)
 	}

--- a/internal/sources/httpx_test.go
+++ b/internal/sources/httpx_test.go
@@ -373,7 +373,7 @@ func TestHTTPXNormalizesOutput(t *testing.T) {
 	}
 
 	outputDir := t.TempDir()
-	sink, err := pipeline.NewSink(outputDir, false, "example.com")
+	sink, err := pipeline.NewSink(outputDir, false, "example.com", pipeline.LineBufferSize(1))
 	if err != nil {
 		t.Fatalf("new sink: %v", err)
 	}


### PR DESCRIPTION
## Summary
- reduce locking overhead in `lazyWriter` and add handler timing metrics for sink processing
- allow configuring the sink line buffer size and derive it from the worker count in the app
- update tests to pass the new buffer size hint when constructing sinks

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e3ee3dcd448329858cd8a3c5c684b1