### PR TITLE
Consolidate LinkFinder outputs under routes directory

### DIFF
--- a/internal/sources/linkfinderevo.go
+++ b/internal/sources/linkfinderevo.go
@@ -142,11 +142,6 @@ func LinkFinderEVO(ctx context.Context, target string, outdir string, out chan<-
 		return err
 	}
 
-	gfDir := filepath.Join(outdir, "linkfindings")
-	if err := os.MkdirAll(gfDir, 0o755); err != nil {
-		return err
-	}
-
 	inputs := []struct {
 		label string
 		path  string
@@ -224,7 +219,7 @@ func LinkFinderEVO(ctx context.Context, target string, outdir string, out chan<-
 			if err := persistLinkfinderArtifacts(findingsDir, input.label, rawPath, htmlPath, jsonPath); err != nil {
 				recordLinkfinderError(&firstErr, err)
 			}
-			if err := persistLinkfinderGFArtifacts(gfDir, input.label, tmpDir); err != nil {
+			if err := persistLinkfinderGFArtifacts(findingsDir, input.label, tmpDir); err != nil {
 				recordLinkfinderError(&firstErr, err)
 			}
 		}
@@ -430,6 +425,12 @@ func cleanupLinkfinderOutputs(findingsDir string) {
 		"findings.json",
 		"findings.raw",
 		"findings.html",
+		"gf.html.txt",
+		"gf.html.json",
+		"gf.js.txt",
+		"gf.js.json",
+		"gf.crawl.txt",
+		"gf.crawl.json",
 		"undetected.active",
 		"findings.active",
 		"findings.html.raw",
@@ -466,13 +467,13 @@ func persistLinkfinderArtifacts(findingsDir, label, rawPath, htmlPath, jsonPath 
 	return nil
 }
 
-func persistLinkfinderGFArtifacts(gfDir, label, srcDir string) error {
+func persistLinkfinderGFArtifacts(findingsDir, label, srcDir string) error {
 	outputs := []struct {
 		name string
 		dest string
 	}{
-		{name: "gf.txt", dest: filepath.Join(gfDir, fmt.Sprintf("gf.%s.txt", label))},
-		{name: "gf.json", dest: filepath.Join(gfDir, fmt.Sprintf("gf.%s.json", label))},
+		{name: "gf.txt", dest: filepath.Join(findingsDir, fmt.Sprintf("gf.%s.txt", label))},
+		{name: "gf.json", dest: filepath.Join(findingsDir, fmt.Sprintf("gf.%s.json", label))},
 	}
 
 	for _, output := range outputs {

--- a/internal/sources/linkfinderevo_test.go
+++ b/internal/sources/linkfinderevo_test.go
@@ -2,8 +2,8 @@ package sources
 
 import (
 	"context"
-	"fmt"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
@@ -340,5 +340,15 @@ func TestLinkFinderEVOIntegrationGeneratesReports(t *testing.T) {
 		if _, err := os.Stat(filepath.Join(findingsDir, name)); err != nil {
 			t.Fatalf("expected intermediate artifact %s: %v", name, err)
 		}
+	}
+
+	for _, name := range []string{"gf.html.txt", "gf.html.json"} {
+		if _, err := os.Stat(filepath.Join(findingsDir, name)); err != nil {
+			t.Fatalf("expected gf artifact %s: %v", name, err)
+		}
+	}
+
+	if _, err := os.Stat(filepath.Join(tmp, "linkfindings")); err == nil || !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("unexpected legacy linkfindings directory state: err=%v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- ensure LinkFinderEVO stores all LinkFinder artifacts inside routes/linkFindings and removes the legacy root-level directory
- update cleanup logic and integration test expectations for the new artifact layout

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e3f9871ae88329bbfb615763dfe660