### PR TITLE
Handle wildcard RDAP targets

### DIFF
--- a/internal/sources/rdap_test.go
+++ b/internal/sources/rdap_test.go
@@ -144,6 +144,29 @@ func TestRDAPFetch(t *testing.T) {
 	}
 }
 
+func TestNormalizeRDAPDomain(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]string{
+		"example.com":               "example.com",
+		"*.example.com":             "example.com",
+		"*example.com":              "example.com",
+		"https://*.example.com":     "example.com",
+		"https://*example.com":      "example.com",
+		"":                          "",
+		"invalid":                   "",
+		"*.sub.*.example.com":       "sub.example.com",
+		"https://*.sub.example.com": "sub.example.com",
+	}
+
+	for input, want := range cases {
+		got := normalizeRDAPDomain(input)
+		if got != want {
+			t.Fatalf("normalizeRDAPDomain(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
 func diffStrings(got, want []string) string {
 	if len(got) != len(want) {
 		return "length mismatch"


### PR DESCRIPTION
## Summary
- normalize RDAP inputs so wildcard targets resolve to their base domain
- add tests covering the new normalization helper

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e422f739fc8329b42f84ba3214676e