### PR TITLE
Reduce GoLinkfinderEVO depth and sampling limit

### DIFF
--- a/internal/sources/linkfinderevo.go
+++ b/internal/sources/linkfinderevo.go
@@ -27,7 +27,7 @@ var (
 )
 
 const (
-	linkfinderMaxInputEntries  = 500
+	linkfinderMaxInputEntries  = 200
 	linkfinderEntriesPerSecond = 15
 )
 
@@ -331,7 +331,7 @@ func writeLinkfinderOutputs(outdir string, aggregate *linkfinderAggregate, out c
 }
 
 func buildLinkfinderArgs(inputPath, target, rawPath, htmlPath, jsonPath string) []string {
-	args := []string{"-i", inputPath, "-d", "-max-depth", "5", "--insecure"}
+	args := []string{"-i", inputPath, "-d", "-max-depth", "2", "--insecure"}
 	scope := normalizeScope(target)
 	if scope != "" {
 		args = append(args, "-scope", scope, "--scope-include-subdomains")


### PR DESCRIPTION
## Summary
- reduce the GoLinkfinderEVO maximum depth from 5 to 2 when building the command arguments
- lower the GoLinkfinderEVO sampling limit from 500 to 200 entries to cap total queries

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e4375ded048329a0260f3a124f7eb2