### PR TITLE
Record artifact provenance per tool

### DIFF
--- a/internal/app/orchestrator_test.go
+++ b/internal/app/orchestrator_test.go
@@ -151,7 +151,7 @@ func TestRunPipelineConcurrentSourcesDedupesSink(t *testing.T) {
 				started <- name
 				<-release
 				for _, line := range lines {
-					opts.sink.In() <- line
+					opts.sink.In() <- pipeline.WrapWithTool(name, line)
 				}
 				return nil
 			},


### PR DESCRIPTION
## Summary
- capture the originating tool for each artifact and aggregate occurrences when flushing the manifest
- update the orchestrator to route tool-labelled output without disturbing existing sinks
- add regression coverage ensuring artifact manifests record tool lists and counts

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e51faa6d608329a14ece10b7000f77