### PR TITLE
Fix tests after category detection updates

### DIFF
--- a/internal/routes/categories_test.go
+++ b/internal/routes/categories_test.go
@@ -18,9 +18,9 @@ func TestDetectCategories(t *testing.T) {
 		{name: "json", input: "https://example.com/config.json", want: []Category{CategoryJSON, CategoryMeta}},
 		{name: "api json", input: "https://example.com/openapi.json", want: []Category{CategoryAPI}},
 		{name: "crawl xml", input: "https://example.com/sitemap.xml", want: []Category{CategoryCrawl}},
-		{name: "crawl robots", input: "robots.txt", want: []Category{CategoryCrawl}},
-		{name: "meta", input: "https://example.com/backup.zip", want: []Category{CategoryMeta}},
-		{name: "multiple", input: "https://example.com/backup.zip?token=abc", want: []Category{CategoryMeta}},
+		{name: "crawl robots", input: "robots.txt", want: []Category{CategoryCrawl, CategoryDocs}},
+		{name: "meta", input: "https://example.com/backup.zip", want: []Category{CategoryArchives, CategoryMeta}},
+		{name: "multiple", input: "https://example.com/backup.zip?token=abc", want: []Category{CategoryArchives, CategoryMeta}},
 	}
 
 	for _, tt := range tests {

--- a/internal/sources/linkfinderevo.go
+++ b/internal/sources/linkfinderevo.go
@@ -816,7 +816,7 @@ func writeLinkfinderRaw(path string, payload linkfinderPayload) error {
 		fmt.Fprintln(bw, "[Resource] "+report.Resource)
 
 		if len(report.Endpoints) == 0 {
-			fmt.Fprintln(bw, "#   No endpoints were found.\n")
+			fmt.Fprintln(bw, "#   No endpoints were found.")
 			continue
 		}
 		for _, ep := range report.Endpoints {

--- a/internal/sources/linkfinderevo_test.go
+++ b/internal/sources/linkfinderevo_test.go
@@ -57,10 +57,10 @@ func TestClassifyLinkfinderEndpoint(t *testing.T) {
 		wantImage  bool
 		wantCats   []routes.Category
 	}{
-		{name: "javascript absolute", input: "https://example.com/app/main.js", wantJS: true},
-		{name: "html absolute", input: "https://example.com/index.html", wantHTML: true},
-		{name: "image absolute", input: "https://example.com/static/logo.png", wantImage: true},
-		{name: "relative path", input: "api/v1/users", undetected: true},
+		{name: "javascript absolute", input: "https://example.com/app/main.js", wantJS: true, wantCats: []routes.Category{routes.CategoryJS}},
+		{name: "html absolute", input: "https://example.com/index.html", wantHTML: true, wantCats: []routes.Category{routes.CategoryHTML}},
+		{name: "image absolute", input: "https://example.com/static/logo.png", wantImage: true, wantCats: []routes.Category{routes.CategoryImages}},
+		{name: "relative path", input: "api/v1/users", undetected: true, wantCats: []routes.Category{routes.CategoryAPI}},
 		{name: "svg relative", input: "logo.svg", undetected: true, wantImage: true, wantCats: []routes.Category{routes.CategorySVG}},
 		{name: "wasm", input: "https://example.com/app.wasm", wantCats: []routes.Category{routes.CategoryWASM}},
 	}


### PR DESCRIPTION
## Summary
- remove redundant newline from linkfinder raw writer to satisfy Go 1.22 vet
- update route category expectations for new archives/docs classifications
- adjust linkfinder endpoint tests to assert new category outputs

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e66924996c83299e553dfa3f59a289