### PR TITLE
Refactor artifact handling into dedicated module

### DIFF
--- a/internal/app/orchestrator_test.go
+++ b/internal/app/orchestrator_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
+	"passive-rec/internal/artifacts"
 	"passive-rec/internal/config"
 	"passive-rec/internal/pipeline"
 )
@@ -262,7 +263,7 @@ func TestRunPipelineConcurrentSourcesDedupesSink(t *testing.T) {
 
 func TestStepDedupeRunsDNSXWhenActive(t *testing.T) {
 	dir := t.TempDir()
-	writeOrchestratorArtifacts(t, dir, []pipeline.Artifact{{Type: "domain", Value: "one.example.com", Up: true}})
+	writeOrchestratorArtifacts(t, dir, []artifacts.Artifact{{Type: "domain", Value: "one.example.com", Up: true}})
 
 	originalDNSX := sourceDNSX
 	defer func() { sourceDNSX = originalDNSX }()
@@ -294,7 +295,7 @@ func TestStepDedupeRunsDNSXWhenActive(t *testing.T) {
 	}
 }
 
-func writeOrchestratorArtifacts(t *testing.T, outdir string, artifacts []pipeline.Artifact) {
+func writeOrchestratorArtifacts(t *testing.T, outdir string, artifacts []artifacts.Artifact) {
 	t.Helper()
 	path := filepath.Join(outdir, "artifacts.jsonl")
 	file, err := os.Create(path)

--- a/internal/artifacts/artifact.go
+++ b/internal/artifacts/artifact.go
@@ -1,0 +1,399 @@
+package artifacts
+
+import (
+	"net"
+	"net/url"
+	"sort"
+	"strings"
+)
+
+// Artifact representa un hallazgo generado por el pipeline y serializado en el
+// manifiesto JSONL.
+type Artifact struct {
+	Type        string         `json:"type"`
+	Types       []string       `json:"types,omitempty"`
+	Value       string         `json:"value"`
+	Active      bool           `json:"active"`
+	Up          bool           `json:"up"`
+	Metadata    map[string]any `json:"metadata,omitempty"`
+	Tool        string         `json:"tool,omitempty"`
+	Tools       []string       `json:"tools,omitempty"`
+	Occurrences int            `json:"occurrences,omitempty"`
+}
+
+// Key representa la identidad lógica de un artefacto normalizado.
+type Key struct {
+	Type   string
+	Value  string
+	Active bool
+}
+
+// Normalize limpia y consolida la información de un artefacto. Devuelve el
+// artefacto normalizado junto con un indicador que señala si el proceso fue
+// exitoso.
+func Normalize(tool string, artifact Artifact) (Artifact, bool) {
+	artifact.Type = strings.TrimSpace(artifact.Type)
+	artifact.Value = strings.TrimSpace(artifact.Value)
+	if artifact.Value == "" {
+		return Artifact{}, false
+	}
+
+	primary, extras, ok := consolidateTypes(artifact.Type, artifact.Types...)
+	if !ok {
+		return Artifact{}, false
+	}
+	artifact.Type = primary
+	artifact.Types = extras
+
+	artifact.Metadata = normalizeMetadata(artifact.Metadata)
+	artifact.Tool = strings.TrimSpace(artifact.Tool)
+	if artifact.Tool == "" {
+		artifact.Tool = strings.TrimSpace(tool)
+	}
+	artifact.Tools = nil
+	artifact.Occurrences = 0
+	return artifact, true
+}
+
+// KeyFor devuelve la clave de deduplicación asociada al artefacto indicado.
+func KeyFor(artifact Artifact) Key {
+	category := keyCategory(artifact.Type)
+	key := Key{
+		Type:   category,
+		Value:  strings.TrimSpace(artifact.Value),
+		Active: artifact.Active,
+	}
+	if key.Type == "route" {
+		if canonical := canonicalRouteKey(key.Value); canonical != "" {
+			key.Value = canonical
+		}
+	}
+	if key.Type == "" {
+		key.Type = "?"
+	}
+	return key
+}
+
+// MergeMetadata fusiona los metadatos entrantes con los existentes en el
+// artefacto destino respetando la semántica esperada para la clave "raw".
+func MergeMetadata(dst *Artifact, metadata map[string]any) {
+	if dst == nil || metadata == nil {
+		return
+	}
+	if dst.Metadata == nil {
+		dst.Metadata = make(map[string]any, len(metadata))
+	}
+	for key, value := range metadata {
+		if key == "" || value == nil {
+			continue
+		}
+		if key == "raw" {
+			mergeRawMetadata(dst.Metadata, value)
+			continue
+		}
+		if _, exists := dst.Metadata[key]; !exists {
+			dst.Metadata[key] = value
+		}
+	}
+}
+
+// MergeTypes combina el tipo principal y los adicionales asegurando una vista
+// coherente en el artefacto destino.
+func MergeTypes(dst *Artifact, primary string, types []string) {
+	if dst == nil {
+		return
+	}
+	extras := append([]string{}, dst.Types...)
+	extras = append(extras, primary)
+	extras = append(extras, types...)
+	normalizedPrimary, merged, ok := consolidateTypes(dst.Type, extras...)
+	if !ok {
+		dst.Type = ""
+		dst.Types = nil
+		return
+	}
+	dst.Type = normalizedPrimary
+	dst.Types = merged
+}
+
+// ExtractRouteBase devuelve la forma normalizada de una ruta para efectos de
+// deduplicación y comparación.
+func ExtractRouteBase(line string) string {
+	trimmed := strings.TrimSpace(line)
+	if trimmed == "" {
+		return ""
+	}
+	if idx := strings.IndexAny(trimmed, " \t"); idx != -1 {
+		trimmed = trimmed[:idx]
+	}
+	trimmed = strings.TrimSpace(trimmed)
+	if trimmed == "" {
+		return ""
+	}
+
+	u, err := url.Parse(trimmed)
+	if err != nil {
+		return trimmed
+	}
+	if u.Scheme == "" && u.Host == "" {
+		return trimmed
+	}
+
+	if scheme := strings.ToLower(u.Scheme); scheme != "" {
+		u.Scheme = scheme
+	}
+
+	if host := u.Hostname(); host != "" {
+		hostname := strings.ToLower(host)
+		port := u.Port()
+		if (u.Scheme == "http" && port == "80") || (u.Scheme == "https" && port == "443") {
+			port = ""
+		}
+		normalizedHost := hostname
+		if port != "" {
+			normalizedHost = net.JoinHostPort(hostname, port)
+		}
+		if u.User != nil {
+			normalizedHost = u.User.String() + "@" + normalizedHost
+		}
+		u.Host = normalizedHost
+	}
+
+	return strings.TrimSpace(u.String())
+}
+
+func canonicalRouteKey(value string) string {
+	base := ExtractRouteBase(value)
+	if base == "" {
+		return ""
+	}
+
+	parsed, err := url.Parse(base)
+	if err != nil || parsed == nil {
+		trimmed := strings.TrimSpace(base)
+		trimmed = strings.TrimPrefix(trimmed, "http://")
+		trimmed = strings.TrimPrefix(trimmed, "https://")
+		return trimmed
+	}
+
+	host := parsed.Hostname()
+	if host == "" {
+		trimmed := strings.TrimSpace(base)
+		trimmed = strings.TrimPrefix(trimmed, "http://")
+		trimmed = strings.TrimPrefix(trimmed, "https://")
+		return trimmed
+	}
+
+	hostname := strings.ToLower(host)
+	port := parsed.Port()
+	if (parsed.Scheme == "http" && port == "80") || (parsed.Scheme == "https" && port == "443") {
+		port = ""
+	}
+
+	normalizedHost := hostname
+	if port != "" {
+		normalizedHost = net.JoinHostPort(hostname, port)
+	}
+	if parsed.User != nil {
+		normalizedHost = parsed.User.String() + "@" + normalizedHost
+	}
+
+	var builder strings.Builder
+	builder.Grow(len(normalizedHost) + len(base))
+	builder.WriteString(normalizedHost)
+
+	path := parsed.EscapedPath()
+	if path != "" && path != "/" {
+		builder.WriteString(path)
+	} else if path == "/" {
+		builder.WriteString("/")
+	}
+
+	if parsed.RawQuery != "" {
+		builder.WriteByte('?')
+		builder.WriteString(parsed.RawQuery)
+	}
+
+	if parsed.Fragment != "" {
+		builder.WriteByte('#')
+		builder.WriteString(parsed.Fragment)
+	}
+
+	result := strings.TrimSpace(builder.String())
+	if result == "" {
+		return base
+	}
+	return result
+}
+
+func keyCategory(typ string) string {
+	switch strings.TrimSpace(typ) {
+	case "", "route", "html", "js", "image", "maps", "json", "api", "wasm", "svg", "crawl", "meta-route":
+		return "route"
+	default:
+		return strings.TrimSpace(typ)
+	}
+}
+
+func normalizeMetadata(metadata map[string]any) map[string]any {
+	if len(metadata) == 0 {
+		return nil
+	}
+	cleaned := make(map[string]any)
+	for key, value := range metadata {
+		key = strings.TrimSpace(key)
+		if key == "" || value == nil {
+			continue
+		}
+		cleaned[key] = value
+	}
+	if len(cleaned) == 0 {
+		return nil
+	}
+	return cleaned
+}
+
+func consolidateTypes(primary string, extras ...string) (string, []string, bool) {
+	typeSet := make(map[string]struct{})
+	addType := func(value string) {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			typeSet[value] = struct{}{}
+		}
+	}
+	addType(primary)
+	for _, value := range extras {
+		addType(value)
+	}
+	if len(typeSet) == 0 {
+		return "", nil, false
+	}
+
+	ordered := make([]string, 0, len(typeSet))
+	for typ := range typeSet {
+		ordered = append(ordered, typ)
+	}
+	sort.Strings(ordered)
+
+	normalizedPrimary := strings.TrimSpace(primary)
+	if normalizedPrimary == "" {
+		normalizedPrimary = ordered[0]
+	} else if _, ok := typeSet[normalizedPrimary]; !ok {
+		normalizedPrimary = ordered[0]
+	}
+
+	extrasList := make([]string, 0, len(ordered)-1)
+	for _, typ := range ordered {
+		if typ == normalizedPrimary {
+			continue
+		}
+		extrasList = append(extrasList, typ)
+	}
+	if len(extrasList) == 0 {
+		extrasList = nil
+	}
+	return normalizedPrimary, extrasList, true
+}
+
+func mergeRawMetadata(target map[string]any, incoming any) {
+	if target == nil || incoming == nil {
+		return
+	}
+
+	addRaw := func(list []string, candidate string) []string {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "" {
+			return list
+		}
+		for _, existing := range list {
+			if existing == candidate {
+				return list
+			}
+		}
+		return append(list, candidate)
+	}
+
+	switch src := incoming.(type) {
+	case string:
+		if existing, ok := target["raw"]; ok {
+			switch current := existing.(type) {
+			case string:
+				if strings.TrimSpace(current) == strings.TrimSpace(src) || strings.TrimSpace(src) == "" {
+					return
+				}
+				target["raw"] = []string{strings.TrimSpace(current), strings.TrimSpace(src)}
+			case []string:
+				target["raw"] = addRaw(current, src)
+			case []any:
+				var list []string
+				for _, candidate := range current {
+					if s, ok := candidate.(string); ok {
+						list = addRaw(list, s)
+					}
+				}
+				target["raw"] = addRaw(list, src)
+			default:
+				target["raw"] = strings.TrimSpace(src)
+			}
+			return
+		}
+		trimmed := strings.TrimSpace(src)
+		if trimmed != "" {
+			target["raw"] = trimmed
+		}
+	case []string:
+		var list []string
+		if existing, ok := target["raw"]; ok {
+			switch current := existing.(type) {
+			case string:
+				list = addRaw(list, current)
+			case []string:
+				list = append(list, current...)
+			case []any:
+				for _, candidate := range current {
+					if s, ok := candidate.(string); ok {
+						list = addRaw(list, s)
+					}
+				}
+			}
+		}
+		for _, candidate := range src {
+			list = addRaw(list, candidate)
+		}
+		if len(list) == 1 {
+			target["raw"] = list[0]
+		} else if len(list) > 1 {
+			target["raw"] = list
+		}
+	case []any:
+		var list []string
+		if existing, ok := target["raw"]; ok {
+			switch current := existing.(type) {
+			case string:
+				list = addRaw(list, current)
+			case []string:
+				list = append(list, current...)
+			case []any:
+				for _, candidate := range current {
+					if s, ok := candidate.(string); ok {
+						list = addRaw(list, s)
+					}
+				}
+			}
+		}
+		for _, candidate := range src {
+			if s, ok := candidate.(string); ok {
+				list = addRaw(list, s)
+			}
+		}
+		if len(list) == 1 {
+			target["raw"] = list[0]
+		} else if len(list) > 1 {
+			target["raw"] = list
+		}
+	default:
+		if _, ok := target["raw"]; !ok {
+			target["raw"] = src
+		}
+	}
+}

--- a/internal/artifacts/reader.go
+++ b/internal/artifacts/reader.go
@@ -8,8 +8,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-
-	"passive-rec/internal/pipeline"
 )
 
 // ActiveState defines the activity filter applied when collecting artifacts.
@@ -74,7 +72,7 @@ func CollectValuesByType(outdir string, selectors map[string]ActiveState) (map[s
 // CollectArtifactsByType lee artifacts.jsonl desde el directorio proporcionado y
 // devuelve los artefactos agrupados por tipo aplicando el filtro de actividad
 // indicado por selectors.
-func CollectArtifactsByType(outdir string, selectors map[string]ActiveState) (map[string][]pipeline.Artifact, error) {
+func CollectArtifactsByType(outdir string, selectors map[string]ActiveState) (map[string][]Artifact, error) {
 	path := filepath.Join(outdir, "artifacts.jsonl")
 	file, err := os.Open(path)
 	if err != nil {
@@ -85,14 +83,14 @@ func CollectArtifactsByType(outdir string, selectors map[string]ActiveState) (ma
 	buf := bufio.NewScanner(file)
 	buf.Buffer(make([]byte, 0, 64*1024), 2*1024*1024)
 
-	result := make(map[string][]pipeline.Artifact, len(selectors))
+	result := make(map[string][]Artifact, len(selectors))
 	for buf.Scan() {
 		line := strings.TrimSpace(buf.Text())
 		if line == "" {
 			continue
 		}
 
-		var artifact pipeline.Artifact
+		var artifact Artifact
 		if err := json.Unmarshal([]byte(line), &artifact); err != nil {
 			return nil, fmt.Errorf("unmarshal artifact: %w", err)
 		}

--- a/internal/artifacts/reader_test.go
+++ b/internal/artifacts/reader_test.go
@@ -7,15 +7,13 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-
-	"passive-rec/internal/pipeline"
 )
 
 func TestCollectArtifactsByTypeMultiTypeRecords(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	artifact := pipeline.Artifact{
+	artifact := Artifact{
 		Type:   "route",
 		Types:  []string{"html"},
 		Value:  "https://app.example.com/login",
@@ -24,7 +22,7 @@ func TestCollectArtifactsByTypeMultiTypeRecords(t *testing.T) {
 	}
 
 	path := filepath.Join(dir, "artifacts.jsonl")
-	writeArtifactsFile(t, path, []pipeline.Artifact{artifact})
+	writeArtifactsFile(t, path, []Artifact{artifact})
 
 	selectors := map[string]ActiveState{
 		"route": PassiveOnly,
@@ -73,7 +71,7 @@ func TestCollectArtifactsByTypeMultiTypeRecords(t *testing.T) {
 	}
 }
 
-func writeArtifactsFile(t *testing.T, path string, artifacts []pipeline.Artifact) {
+func writeArtifactsFile(t *testing.T, path string, artifacts []Artifact) {
 	t.Helper()
 
 	f, err := os.Create(path)

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -12,9 +12,12 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
+	"passive-rec/internal/artifacts"
 	"passive-rec/internal/certs"
 	"passive-rec/internal/netutil"
 )
+
+type Artifact = artifacts.Artifact
 
 func newTestSink(t *testing.T, active bool) (*Sink, string) {
 	t.Helper()
@@ -1418,17 +1421,18 @@ func containsType(types []string, typ string) bool {
 	return false
 }
 
-func findRouteArtifactByCanonical(t *testing.T, artifacts []Artifact, value string, active bool) Artifact {
+func findRouteArtifactByCanonical(t *testing.T, records []Artifact, value string, active bool) Artifact {
 	t.Helper()
-	canonical := canonicalRouteKey(value)
-	for _, art := range artifacts {
+	expectedKey := artifacts.KeyFor(artifacts.Artifact{Type: "route", Value: value, Active: active})
+	for _, art := range records {
 		if strings.TrimSpace(art.Type) != "route" {
 			continue
 		}
 		if art.Active != active {
 			continue
 		}
-		if canonicalRouteKey(art.Value) == canonical {
+		candidateKey := artifacts.KeyFor(artifacts.Artifact{Type: art.Type, Value: art.Value, Active: art.Active})
+		if candidateKey.Value == expectedKey.Value && candidateKey.Active == expectedKey.Active {
 			return art
 		}
 	}

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -20,7 +20,6 @@ import (
 	"passive-rec/internal/certs"
 	"passive-rec/internal/config"
 	"passive-rec/internal/netutil"
-	"passive-rec/internal/pipeline"
 )
 
 // Generate reads the artifact manifest and renders an HTML report in cfg.OutDir.
@@ -43,7 +42,7 @@ func Generate(ctx context.Context, cfg *config.Config) error {
 		"certificate": artifacts.PassiveOnly,
 		"meta":        artifacts.PassiveOnly,
 	}
-	var passiveArtifacts map[string][]pipeline.Artifact
+	var passiveArtifacts map[string][]artifacts.Artifact
 	if exists {
 		passiveArtifacts, err = artifacts.CollectArtifactsByType(cfg.OutDir, selectors)
 		if err != nil {
@@ -70,7 +69,7 @@ func Generate(ctx context.Context, cfg *config.Config) error {
 			"dns":         artifacts.ActiveOnly,
 		}
 
-		var activeArtifacts map[string][]pipeline.Artifact
+		var activeArtifacts map[string][]artifacts.Artifact
 		if exists {
 			activeArtifacts, err = artifacts.CollectArtifactsByType(cfg.OutDir, activeSelectors)
 			if err != nil {
@@ -271,12 +270,12 @@ var (
 	}
 )
 
-func artifactValues(artifacts []pipeline.Artifact) []string {
-	if len(artifacts) == 0 {
+func artifactValues(list []artifacts.Artifact) []string {
+	if len(list) == 0 {
 		return nil
 	}
-	values := make([]string, 0, len(artifacts))
-	for _, artifact := range artifacts {
+	values := make([]string, 0, len(list))
+	for _, artifact := range list {
 		value := cleanReportText(artifact.Value)
 		if value == "" {
 			continue
@@ -289,12 +288,12 @@ func artifactValues(artifacts []pipeline.Artifact) []string {
 	return values
 }
 
-func artifactRawValues(artifacts []pipeline.Artifact) []string {
-	if len(artifacts) == 0 {
+func artifactRawValues(list []artifacts.Artifact) []string {
+	if len(list) == 0 {
 		return nil
 	}
-	values := make([]string, 0, len(artifacts))
-	for _, artifact := range artifacts {
+	values := make([]string, 0, len(list))
+	for _, artifact := range list {
 		candidates := make([]string, 0, 1)
 		if artifact.Metadata != nil {
 			switch raw := artifact.Metadata["raw"].(type) {
@@ -327,12 +326,12 @@ func artifactRawValues(artifacts []pipeline.Artifact) []string {
 	return values
 }
 
-func parseDNSArtifacts(artifacts []pipeline.Artifact) ([]dnsRecord, error) {
-	if len(artifacts) == 0 {
+func parseDNSArtifacts(list []artifacts.Artifact) ([]dnsRecord, error) {
+	if len(list) == 0 {
 		return nil, nil
 	}
-	records := make([]dnsRecord, 0, len(artifacts))
-	for _, artifact := range artifacts {
+	records := make([]dnsRecord, 0, len(list))
+	for _, artifact := range list {
 		value := strings.TrimSpace(artifact.Value)
 		if value == "" {
 			continue

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -9,9 +9,9 @@ import (
 	"testing"
 	"time"
 
+	"passive-rec/internal/artifacts"
 	"passive-rec/internal/certs"
 	"passive-rec/internal/config"
-	"passive-rec/internal/pipeline"
 )
 
 func TestGenerateCreatesHTMLReport(t *testing.T) {
@@ -48,7 +48,7 @@ func TestGenerateCreatesHTMLReport(t *testing.T) {
 		t.Fatalf("marshal certThree: %v", err)
 	}
 
-	writeArtifacts(t, dir, []pipeline.Artifact{
+	writeArtifacts(t, dir, []artifacts.Artifact{
 		{Type: "domain", Value: "app.example.com", Active: false, Up: true},
 		{Type: "domain", Value: "api.example.com", Active: false, Up: true},
 		{Type: "domain", Value: "static.test.com", Active: false, Up: true},
@@ -138,7 +138,7 @@ func TestGenerateIncludesActiveData(t *testing.T) {
 		t.Fatalf("marshal dns record: %v", err)
 	}
 
-	writeArtifacts(t, dir, []pipeline.Artifact{
+	writeArtifacts(t, dir, []artifacts.Artifact{
 		{Type: "domain", Value: "example.com", Active: false, Up: true},
 		{Type: "route", Value: "https://example.com", Active: false, Up: true},
 		{Type: "meta", Value: "passive: ok", Active: false, Up: true},
@@ -362,7 +362,7 @@ func TestBuildCertStatsGroupsMultiLevelTLDs(t *testing.T) {
 	}
 }
 
-func writeArtifacts(t *testing.T, dir string, artifacts []pipeline.Artifact) {
+func writeArtifacts(t *testing.T, dir string, artifacts []artifacts.Artifact) {
 	t.Helper()
 	var builder strings.Builder
 	for _, artifact := range artifacts {

--- a/internal/sources/httpx_test.go
+++ b/internal/sources/httpx_test.go
@@ -14,10 +14,11 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
+	"passive-rec/internal/artifacts"
 	"passive-rec/internal/pipeline"
 )
 
-func writeArtifactsFile(t *testing.T, outdir string, artifacts []pipeline.Artifact) {
+func writeArtifactsFile(t *testing.T, outdir string, artifacts []artifacts.Artifact) {
 	t.Helper()
 	path := filepath.Join(outdir, "artifacts.jsonl")
 	file, err := os.Create(path)
@@ -36,7 +37,7 @@ func writeArtifactsFile(t *testing.T, outdir string, artifacts []pipeline.Artifa
 
 func TestHTTPXCombinesAllLists(t *testing.T) {
 	tmp := t.TempDir()
-	writeArtifactsFile(t, tmp, []pipeline.Artifact{
+	writeArtifactsFile(t, tmp, []artifacts.Artifact{
 		{Type: "domain", Value: "example.com", Up: true},
 		{Type: "domain", Value: "sub.example.com", Up: true},
 		{Type: "route", Value: "https://app.example.com/login", Up: true},
@@ -107,7 +108,7 @@ func TestHTTPXCombinesAllLists(t *testing.T) {
 
 func TestCollectHTTPXInputsDedupesAndReportsMissing(t *testing.T) {
 	tmp := t.TempDir()
-	writeArtifactsFile(t, tmp, []pipeline.Artifact{
+	writeArtifactsFile(t, tmp, []artifacts.Artifact{
 		{Type: "domain", Value: "example.com", Up: true},
 		{Type: "domain", Value: "# comment", Up: true},
 		{Type: "route", Value: "https://assets.example.com/favicon.ico", Up: true},
@@ -311,7 +312,7 @@ func TestRunHTTPXWorkersCancellation(t *testing.T) {
 
 func TestHTTPXProcessesRouteArtifactsOnly(t *testing.T) {
 	tmp := t.TempDir()
-	writeArtifactsFile(t, tmp, []pipeline.Artifact{{Type: "route", Value: "https://app.example.com/login", Up: true}})
+	writeArtifactsFile(t, tmp, []artifacts.Artifact{{Type: "route", Value: "https://app.example.com/login", Up: true}})
 
 	originalBinFinder := httpxBinFinder
 	originalRunCmd := httpxRunCmd
@@ -377,7 +378,7 @@ func TestHTTPXProcessesRouteArtifactsOnly(t *testing.T) {
 
 func TestHTTPXNormalizesOutput(t *testing.T) {
 	inputDir := t.TempDir()
-	writeArtifactsFile(t, inputDir, []pipeline.Artifact{{Type: "route", Value: "https://app.example.com", Up: true}})
+	writeArtifactsFile(t, inputDir, []artifacts.Artifact{{Type: "route", Value: "https://app.example.com", Up: true}})
 
 	originalBinFinder := httpxBinFinder
 	originalRunCmd := httpxRunCmd
@@ -472,7 +473,7 @@ func TestHTTPXNormalizesOutput(t *testing.T) {
 
 func TestHTTPXSkipsUnresponsiveResults(t *testing.T) {
 	inputDir := t.TempDir()
-	writeArtifactsFile(t, inputDir, []pipeline.Artifact{{Type: "route", Value: "https://app.example.com", Up: true}})
+	writeArtifactsFile(t, inputDir, []artifacts.Artifact{{Type: "route", Value: "https://app.example.com", Up: true}})
 
 	originalBinFinder := httpxBinFinder
 	originalRunCmd := httpxRunCmd
@@ -515,7 +516,7 @@ func TestHTTPXSkipsUnresponsiveResults(t *testing.T) {
 
 func TestHTTPXSkipsHTMLForErrorResponses(t *testing.T) {
 	inputDir := t.TempDir()
-	writeArtifactsFile(t, inputDir, []pipeline.Artifact{{Type: "route", Value: "https://missing.example.com", Up: true}})
+	writeArtifactsFile(t, inputDir, []artifacts.Artifact{{Type: "route", Value: "https://missing.example.com", Up: true}})
 
 	originalBinFinder := httpxBinFinder
 	originalRunCmd := httpxRunCmd
@@ -554,7 +555,7 @@ func TestHTTPXSkipsHTMLForErrorResponses(t *testing.T) {
 
 func TestHTTPXIncludesRedirectDomains(t *testing.T) {
 	inputDir := t.TempDir()
-	writeArtifactsFile(t, inputDir, []pipeline.Artifact{{Type: "route", Value: "https://redirect.example.com", Up: true}})
+	writeArtifactsFile(t, inputDir, []artifacts.Artifact{{Type: "route", Value: "https://redirect.example.com", Up: true}})
 
 	originalBinFinder := httpxBinFinder
 	originalRunCmd := httpxRunCmd
@@ -592,9 +593,9 @@ func TestHTTPXIncludesRedirectDomains(t *testing.T) {
 
 func TestHTTPXBatchesLargeInputs(t *testing.T) {
 	inputDir := t.TempDir()
-	var records []pipeline.Artifact
+	var records []artifacts.Artifact
 	for i := 0; i < 5; i++ {
-		records = append(records, pipeline.Artifact{Type: "route", Value: fmt.Sprintf("https://example.com/path-%d", i), Up: true})
+		records = append(records, artifacts.Artifact{Type: "route", Value: fmt.Sprintf("https://example.com/path-%d", i), Up: true})
 	}
 	writeArtifactsFile(t, inputDir, records)
 
@@ -667,7 +668,7 @@ func TestHTTPXBatchesLargeInputs(t *testing.T) {
 
 func TestHTTPXSkipsLowPriorityRoutes(t *testing.T) {
 	tmp := t.TempDir()
-	var artifactsList []pipeline.Artifact
+	var artifactsList []artifacts.Artifact
 	for _, value := range []string{
 		"https://app.example.com/login",
 		"https://app.example.com/favicon.ico",
@@ -679,7 +680,7 @@ func TestHTTPXSkipsLowPriorityRoutes(t *testing.T) {
 		"https://app.example.com/files/THUMBS.DB",
 		"https://app.example.com/assets/raw.pgm",
 	} {
-		artifactsList = append(artifactsList, pipeline.Artifact{Type: "route", Value: value, Up: true})
+		artifactsList = append(artifactsList, artifacts.Artifact{Type: "route", Value: value, Up: true})
 	}
 	writeArtifactsFile(t, tmp, artifactsList)
 

--- a/internal/sources/linkfinderevo_test.go
+++ b/internal/sources/linkfinderevo_test.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"passive-rec/internal/pipeline"
+	"passive-rec/internal/artifacts"
 	"passive-rec/internal/routes"
 )
 
@@ -31,7 +31,7 @@ func writeLinkfinderArtifacts(t *testing.T, outdir string, data map[string][]str
 	encoder := json.NewEncoder(file)
 	for typ, values := range data {
 		for _, value := range values {
-			if err := encoder.Encode(pipeline.Artifact{Type: typ, Value: value, Active: true, Up: true}); err != nil {
+			if err := encoder.Encode(artifacts.Artifact{Type: typ, Value: value, Active: true, Up: true}); err != nil {
 				t.Fatalf("encode artifact: %v", err)
 			}
 		}

--- a/internal/sources/subjs_test.go
+++ b/internal/sources/subjs_test.go
@@ -13,11 +13,11 @@ import (
 	"testing"
 	"time"
 
-	"passive-rec/internal/pipeline"
+	"passive-rec/internal/artifacts"
 	"passive-rec/internal/runner"
 )
 
-func writeSubJSArtifacts(t *testing.T, outdir string, artifacts []pipeline.Artifact) {
+func writeSubJSArtifacts(t *testing.T, outdir string, artifacts []artifacts.Artifact) {
 	t.Helper()
 	path := filepath.Join(outdir, "artifacts.jsonl")
 	file, err := os.Create(path)
@@ -92,7 +92,7 @@ func TestSubJSMissingInputFile(t *testing.T) {
 
 func TestSubJSSuccess(t *testing.T) {
 	dir := t.TempDir()
-	writeSubJSArtifacts(t, dir, []pipeline.Artifact{
+	writeSubJSArtifacts(t, dir, []artifacts.Artifact{
 		{Type: "route", Value: "https://app.example.com/login [200]", Active: true, Up: true},
 		{Type: "route", Value: "https://app.example.com/login", Active: true, Up: true},
 	})
@@ -173,7 +173,7 @@ func TestSubJSSuccess(t *testing.T) {
 
 func TestSubJSAcceptsNonErrorStatuses(t *testing.T) {
 	dir := t.TempDir()
-	writeSubJSArtifacts(t, dir, []pipeline.Artifact{{Type: "route", Value: "https://app.example.com/login", Active: true, Up: true}})
+	writeSubJSArtifacts(t, dir, []artifacts.Artifact{{Type: "route", Value: "https://app.example.com/login", Active: true, Up: true}})
 
 	var server *httptest.Server
 	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- extract artifact structure, normalization, and deduplication helpers into `internal/artifacts/artifact.go`
- update the pipeline to consume the new artifact abstraction and adjust aggregation logic accordingly
- migrate readers, reports, sources, and tests to depend on the artifacts module instead of the pipeline struct

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e67031c0848329bc181a79a94eb0c7