### PR TITLE
Ensure out.Writer flushes buffered data after each write

### DIFF
--- a/internal/out/writer.go
+++ b/internal/out/writer.go
@@ -140,10 +140,18 @@ func (w *Writer) writeUnique(line string) error {
 	if _, err := w.buf.WriteString(line); err != nil {
 		return err
 	}
-	if err := w.buf.WriteByte('\n'); err != nil {
-		return err
-	}
-	return nil
+        if err := w.buf.WriteByte('\n'); err != nil {
+                return err
+        }
+
+        // Flush inmediatamente para que los datos estén disponibles incluso si el
+        // consumidor lee el archivo antes de que Writer.Close sea llamado. Esto
+        // también garantiza que las pruebas que inspeccionan el contenido sin
+        // cerrar explícitamente el escritor vean los resultados.
+        if err := w.buf.Flush(); err != nil {
+                return err
+        }
+        return nil
 }
 
 func (w *Writer) WriteDomain(d string) error {


### PR DESCRIPTION
## Summary
- flush the buffered writer after each unique line so output files are immediately readable
- keep deduplicated sink outputs available before closing the writer

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e67bc52dd48329aa007984bd064d4e