### PR TITLE
Fix lint issues and improve error handling

### DIFF
--- a/cmd/install-deps/main.go
+++ b/cmd/install-deps/main.go
@@ -96,7 +96,9 @@ func parseRequirements(path string) ([]requirement, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer file.Close()
+	defer func() {
+		_ = file.Close()
+	}()
 
 	var reqs []requirement
 	scanner := bufio.NewScanner(file)
@@ -172,7 +174,9 @@ func installFromGit(req requirement) error {
 	if err != nil {
 		return err
 	}
-	defer os.RemoveAll(tempDir)
+	defer func() {
+		_ = os.RemoveAll(tempDir)
+	}()
 
 	clone := exec.Command("git", "clone", req.repo, tempDir)
 	clone.Stdout = os.Stdout

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,7 @@ golang.org/x/net v0.44.0 h1:evd8IRDyfNBMBTTY5XRF1vaZlD+EmWx6x8PkhR04H/I=
 golang.org/x/net v0.44.0/go.mod h1:ECOoLqd5U3Lhyeyo/QDCEVQ4sNgYsqvCZ722XogGieY=
 golang.org/x/sync v0.17.0 h1:l60nONMj9l5drqw6jlhIELNv9I0A4OFgRsG9k2oT9Ug=
 golang.org/x/sync v0.17.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/adapters/artifacts/reader.go
+++ b/internal/adapters/artifacts/reader.go
@@ -78,7 +78,9 @@ func CollectArtifactsByType(outdir string, selectors map[string]ActiveState) (ma
 	if err != nil {
 		return nil, err
 	}
-	defer file.Close()
+	defer func() {
+		_ = file.Close()
+	}()
 
 	buf := bufio.NewScanner(file)
 	buf.Buffer(make([]byte, 0, 64*1024), 2*1024*1024)

--- a/internal/adapters/artifacts/reader_test.go
+++ b/internal/adapters/artifacts/reader_test.go
@@ -78,7 +78,9 @@ func writeArtifactsFile(t *testing.T, path string, artifacts []Artifact) {
 	if err != nil {
 		t.Fatalf("Create(%q): %v", path, err)
 	}
-	defer f.Close()
+	defer func() {
+		_ = f.Close()
+	}()
 
 	encoder := json.NewEncoder(f)
 	for _, artifact := range artifacts {

--- a/internal/adapters/report/report.go
+++ b/internal/adapters/report/report.go
@@ -133,7 +133,9 @@ func Generate(ctx context.Context, cfg *config.Config) error {
 	if err != nil {
 		return fmt.Errorf("report: create %q: %w", reportPath, err)
 	}
-	defer f.Close()
+	defer func() {
+		_ = f.Close()
+	}()
 
 	if err := reportTmpl.Execute(f, data); err != nil {
 		return fmt.Errorf("report: render: %w", err)

--- a/internal/adapters/sources/censys.go
+++ b/internal/adapters/sources/censys.go
@@ -114,7 +114,11 @@ func Censys(ctx context.Context, domain, apiID, apiSecret string, out chan<- str
 		}
 		// Cierre seguro del body
 		func() {
-			defer resp.Body.Close()
+			defer func() {
+				if closeErr := resp.Body.Close(); closeErr != nil && err == nil {
+					err = closeErr
+				}
+			}()
 
 			if resp.StatusCode != http.StatusOK {
 				censysMeta(out, "unexpected HTTP status %d", resp.StatusCode)

--- a/internal/adapters/sources/censys_test.go
+++ b/internal/adapters/sources/censys_test.go
@@ -25,7 +25,7 @@ func TestCensysPagination(t *testing.T) {
 				t.Fatalf("unexpected query: %s", got)
 			}
 			w.Header().Set("Content-Type", "application/json")
-			w.Write([]byte(`{
+			if _, err := w.Write([]byte(`{
   "result": {
     "hits": [
       {
@@ -38,10 +38,12 @@ func TestCensysPagination(t *testing.T) {
     ],
     "links": {"next": "` + serverURL + `/api/v2/certificates/search?page=2"}
   }
-}`))
+}`)); err != nil {
+				t.Fatalf("write response page1: %v", err)
+			}
 		case "2":
 			w.Header().Set("Content-Type", "application/json")
-			w.Write([]byte(`{
+			if _, err := w.Write([]byte(`{
   "result": {
     "hits": [
       {
@@ -54,7 +56,9 @@ func TestCensysPagination(t *testing.T) {
     ],
     "links": {"next": ""}
   }
-}`))
+}`)); err != nil {
+				t.Fatalf("write response page2: %v", err)
+			}
 		default:
 			t.Fatalf("unexpected page: %s", r.URL.Query().Get("page"))
 		}
@@ -156,7 +160,7 @@ func TestCensysHTTPErrorIncludesMeta(t *testing.T) {
 func TestCensysDeduplicatesCaseInsensitive(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(`{
+		if _, err := w.Write([]byte(`{
   "result": {
     "hits": [
       {
@@ -169,7 +173,9 @@ func TestCensysDeduplicatesCaseInsensitive(t *testing.T) {
     ],
     "links": {"next": ""}
   }
-}`))
+}`)); err != nil {
+			t.Fatalf("write case-insensitive response: %v", err)
+		}
 	}))
 	defer srv.Close()
 
@@ -220,23 +226,27 @@ func TestCensysRelativeNextLink(t *testing.T) {
 
 		switch r.URL.Query().Get("page") {
 		case "", "1":
-			w.Write([]byte(`{
+			if _, err := w.Write([]byte(`{
   "result": {
     "hits": [
       {"name": "page1.example.com"}
     ],
     "links": {"next": "/api/v2/certificates/search?page=2"}
   }
-}`))
+}`)); err != nil {
+				t.Fatalf("write relative next page1: %v", err)
+			}
 		case "2":
-			w.Write([]byte(`{
+			if _, err := w.Write([]byte(`{
   "result": {
     "hits": [
       {"name": "page2.example.com"}
     ],
     "links": {"next": ""}
   }
-}`))
+}`)); err != nil {
+				t.Fatalf("write relative next page2: %v", err)
+			}
 		default:
 			t.Fatalf("unexpected page requested: %s", r.URL.Query().Get("page"))
 		}

--- a/internal/adapters/sources/crtsh.go
+++ b/internal/adapters/sources/crtsh.go
@@ -21,7 +21,7 @@ type crtshEntry struct {
 	SerialNumber string `json:"serial_number"`
 }
 
-func CRTSH(ctx context.Context, domain string, out chan<- string) error {
+func CRTSH(ctx context.Context, domain string, out chan<- string) (err error) {
 	logx.Debugf("crtsh query %s", domain)
 
 	u, _ := url.Parse("https://crt.sh/")
@@ -42,7 +42,11 @@ func CRTSH(ctx context.Context, domain string, out chan<- string) error {
 		logx.Errorf("crtsh http: %v", err)
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if closeErr := resp.Body.Close(); err == nil && closeErr != nil {
+			err = closeErr
+		}
+	}()
 
 	if resp.StatusCode != http.StatusOK {
 		logx.Errorf("crtsh non-200: %d", resp.StatusCode)

--- a/internal/adapters/sources/dnsx.go
+++ b/internal/adapters/sources/dnsx.go
@@ -85,7 +85,9 @@ func DNSX(ctx context.Context, domains []string, outDir string, out chan<- strin
 	}
 	// Cleanup garantizado del temp file
 	tmpPath := tmpFile.Name()
-	defer os.Remove(tmpPath)
+	defer func() {
+		_ = os.Remove(tmpPath)
+	}()
 
 	tmpWriter := bufio.NewWriter(tmpFile)
 	for _, domain := range cleaned {

--- a/internal/adapters/sources/httpx_test.go
+++ b/internal/adapters/sources/httpx_test.go
@@ -25,7 +25,9 @@ func writeArtifactsFile(t *testing.T, outdir string, artifacts []artifacts.Artif
 	if err != nil {
 		t.Fatalf("create artifacts.jsonl: %v", err)
 	}
-	defer file.Close()
+	defer func() {
+		_ = file.Close()
+	}()
 
 	encoder := json.NewEncoder(file)
 	for _, artifact := range artifacts {

--- a/internal/adapters/sources/linkfinderevo_test.go
+++ b/internal/adapters/sources/linkfinderevo_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/rand"
 	"os"
 	"path/filepath"
 	"sort"
@@ -26,7 +27,9 @@ func writeLinkfinderArtifacts(t *testing.T, outdir string, data map[string][]str
 	if err != nil {
 		t.Fatalf("create artifacts.jsonl: %v", err)
 	}
-	defer file.Close()
+	defer func() {
+		_ = file.Close()
+	}()
 
 	encoder := json.NewEncoder(file)
 	for typ, values := range data {
@@ -432,7 +435,8 @@ func TestMaybeSampleLinkfinderInputLimitsEntries(t *testing.T) {
 		builder.WriteString(fmt.Sprintf("file://example.com/%d\n", i))
 	}
 
-	path, totalEntries, sampledEntries, err := maybeSampleLinkfinderInput(tmp, "html", []byte(builder.String()), linkfinderMaxInputEntries)
+	rng := rand.New(rand.NewSource(1))
+	path, totalEntries, sampledEntries, err := maybeSampleLinkfinderInput(tmp, "html", []byte(builder.String()), linkfinderMaxInputEntries, rng)
 	if err != nil {
 		t.Fatalf("maybeSampleLinkfinderInput returned error: %v", err)
 	}
@@ -470,7 +474,8 @@ func TestMaybeSampleLinkfinderInputRespectsCustomLimit(t *testing.T) {
 	}
 
 	limit := 25
-	path, totalEntries, sampledEntries, err := maybeSampleLinkfinderInput(tmp, "html", []byte(builder.String()), limit)
+	rng := rand.New(rand.NewSource(2))
+	path, totalEntries, sampledEntries, err := maybeSampleLinkfinderInput(tmp, "html", []byte(builder.String()), limit, rng)
 	if err != nil {
 		t.Fatalf("maybeSampleLinkfinderInput returned error: %v", err)
 	}
@@ -498,7 +503,8 @@ func TestMaybeSampleLinkfinderInputNoopWhenBelowLimit(t *testing.T) {
 	tmp := t.TempDir()
 
 	data := []byte("file://example.com/1\nfile://example.com/2\n")
-	path, totalEntries, sampledEntries, err := maybeSampleLinkfinderInput(tmp, "html", data, linkfinderMaxInputEntries)
+	rng := rand.New(rand.NewSource(3))
+	path, totalEntries, sampledEntries, err := maybeSampleLinkfinderInput(tmp, "html", data, linkfinderMaxInputEntries, rng)
 	if err != nil {
 		t.Fatalf("maybeSampleLinkfinderInput returned error: %v", err)
 	}

--- a/internal/adapters/sources/subjs.go
+++ b/internal/adapters/sources/subjs.go
@@ -152,8 +152,8 @@ func writeSubJSInput(lines []string) (string, func(), error) {
 	}
 
 	cleanup := func() {
-		tmpFile.Close()
-		os.Remove(tmpFile.Name())
+		_ = tmpFile.Close()
+		_ = os.Remove(tmpFile.Name())
 	}
 
 	writer := bufio.NewWriter(tmpFile)
@@ -264,6 +264,8 @@ func doJSRequest(ctx context.Context, client *http.Client, method, url string) (
 	if err != nil {
 		return 0, err
 	}
-	resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 	return resp.StatusCode, nil
 }

--- a/internal/adapters/sources/subjs_test.go
+++ b/internal/adapters/sources/subjs_test.go
@@ -24,7 +24,9 @@ func writeSubJSArtifacts(t *testing.T, outdir string, artifacts []artifacts.Arti
 	if err != nil {
 		t.Fatalf("create artifacts.jsonl: %v", err)
 	}
-	defer file.Close()
+	defer func() {
+		_ = file.Close()
+	}()
 
 	encoder := json.NewEncoder(file)
 	for _, artifact := range artifacts {
@@ -185,7 +187,9 @@ func TestSubJSAcceptsNonErrorStatuses(t *testing.T) {
 			w.WriteHeader(http.StatusFound)
 		case "/final.js":
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte("console.log('ok');"))
+			if _, err := w.Write([]byte("console.log('ok');")); err != nil {
+				t.Fatalf("write final.js response: %v", err)
+			}
 		default:
 			http.NotFound(w, r)
 		}

--- a/internal/core/app/app.go
+++ b/internal/core/app/app.go
@@ -52,7 +52,11 @@ func Run(cfg *config.Config) error {
 	if err != nil {
 		return err
 	}
-	defer sink.Close()
+	defer func() {
+		if err := sink.Close(); err != nil {
+			logx.Warnf("sink close error: %v", err)
+		}
+	}()
 	sink.Start(cfg.Workers)
 
 	requested, ordered, unknown := normalizeRequestedTools(cfg)

--- a/internal/core/app/app_test.go
+++ b/internal/core/app/app_test.go
@@ -392,7 +392,9 @@ func writeArtifactsFile(t *testing.T, outdir string, records []artifacts.Artifac
 	if err != nil {
 		t.Fatalf("create artifacts.jsonl: %v", err)
 	}
-	defer file.Close()
+	defer func() {
+		_ = file.Close()
+	}()
 
 	encoder := json.NewEncoder(file)
 	for _, artifact := range records {
@@ -587,7 +589,9 @@ func appendLine(path, line string) {
 	if err != nil {
 		panic(err)
 	}
-	defer f.Close()
+	defer func() {
+		_ = f.Close()
+	}()
 	if _, err := f.WriteString(line + "\n"); err != nil {
 		panic(err)
 	}

--- a/internal/core/app/dedupe.go
+++ b/internal/core/app/dedupe.go
@@ -84,7 +84,9 @@ func readDedupeFile(outdir string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer file.Close()
+	defer func() {
+		_ = file.Close()
+	}()
 
 	scanner := bufio.NewScanner(file)
 	scanner.Buffer(make([]byte, 0, 64*1024), 2*1024*1024)

--- a/internal/core/app/orchestrator.go
+++ b/internal/core/app/orchestrator.go
@@ -265,7 +265,9 @@ func runSingleStep(ctx context.Context, step toolStep, state *pipelineState, opt
 	if !ok {
 		return
 	}
-	task()
+	if err := task(); err != nil && !errors.Is(err, runner.ErrMissingBinary) {
+		logx.Warnf("source error: %v", err)
+	}
 }
 
 func runConcurrentSteps(ctx context.Context, steps []toolStep, state *pipelineState, opts orchestratorOptions) {

--- a/internal/core/app/orchestrator_test.go
+++ b/internal/core/app/orchestrator_test.go
@@ -302,7 +302,9 @@ func writeOrchestratorArtifacts(t *testing.T, outdir string, artifacts []artifac
 	if err != nil {
 		t.Fatalf("create artifacts.jsonl: %v", err)
 	}
-	defer file.Close()
+	defer func() {
+		_ = file.Close()
+	}()
 
 	encoder := json.NewEncoder(file)
 	for _, artifact := range artifacts {

--- a/internal/core/app/progress.go
+++ b/internal/core/app/progress.go
@@ -40,7 +40,9 @@ func (p *progressBar) renderInitial() {
 
 	bar := strings.Repeat("░", p.width)
 	line := fmt.Sprintf("[%s] 0/%d iniciando...", bar, p.total)
-	fmt.Fprint(p.out, line)
+	if _, err := fmt.Fprint(p.out, line); err != nil {
+		return
+	}
 	p.lastLineLen = len(line)
 	p.lastRendered = line
 }
@@ -135,7 +137,9 @@ func (p *progressBar) StepDone(tool, status string) {
 
 	p.renderLocked(tool, label)
 	if p.current == p.total {
-		fmt.Fprintln(p.out)
+		if _, err := fmt.Fprintln(p.out); err != nil {
+			return
+		}
 		p.lastLineLen = 0
 		p.done = true
 		p.lastRendered = ""
@@ -199,7 +203,9 @@ func (p *progressBar) renderLocked(tool, status string) {
 	if padding > 0 {
 		line += strings.Repeat(" ", padding)
 	}
-	fmt.Fprint(p.out, line)
+	if _, err := fmt.Fprint(p.out, line); err != nil {
+		return
+	}
 	p.lastLineLen = len(line)
 	p.lastRendered = line
 }

--- a/internal/core/pipeline/handler_route.go
+++ b/internal/core/pipeline/handler_route.go
@@ -302,7 +302,7 @@ func routeCategoryHandler(ctx *Context, spec CategorySpec, line string, isActive
 	if base == "" {
 		return false
 	}
-	if !(strings.Contains(base, "://") || strings.HasPrefix(base, "/") || strings.Contains(base, "/")) {
+	if !strings.Contains(base, "://") && !strings.HasPrefix(base, "/") && !strings.Contains(base, "/") {
 		return false
 	}
 	if !ctx.S.scopeAllowsRoute(base) {

--- a/internal/core/pipeline/parseutil.go
+++ b/internal/core/pipeline/parseutil.go
@@ -55,7 +55,7 @@ func inferToolFromMessage(msg string) string {
 
 var (
 	ansiEscapeSequence = regexp.MustCompile("\x1b\\[[0-9;]*[A-Za-z]")
-	ansiColorCode      = regexp.MustCompile("\\[[0-9;]*m")
+	ansiColorCode      = regexp.MustCompile(`\[[0-9;]*m`)
 	ansiOSCSequence    = regexp.MustCompile("\x1b\\][^\x07]*\x07")
 )
 

--- a/internal/core/pipeline/pipeline_test.go
+++ b/internal/core/pipeline/pipeline_test.go
@@ -1350,7 +1350,9 @@ func readArtifactsFile(t *testing.T, path string) []Artifact {
 	if err != nil {
 		t.Fatalf("open artifacts %q: %v", path, err)
 	}
-	defer f.Close()
+	defer func() {
+		_ = f.Close()
+	}()
 
 	scanner := bufio.NewScanner(f)
 	scanner.Buffer(make([]byte, 0, 64*1024), 2*1024*1024)

--- a/internal/core/pipeline/sink.go
+++ b/internal/core/pipeline/sink.go
@@ -365,10 +365,6 @@ func (s *Sink) writer(key string, active bool) sinkWriter {
 	return pair.writer(active)
 }
 
-func (s *Sink) writerPair(key string) writerPair {
-	return s.writers.pair(key)
-}
-
 func (s *Sink) inActiveMode() bool { return s != nil && s.activeMode }
 
 func (s *Sink) scopeAllowsDomain(domain string) bool {

--- a/internal/platform/config/config_test.go
+++ b/internal/platform/config/config_test.go
@@ -172,7 +172,9 @@ func TestConfigureRootCAs(t *testing.T) {
 	originalTransport := http.DefaultTransport
 	t.Cleanup(func() {
 		http.DefaultTransport = originalTransport
-		ConfigureRootCAs("")
+		if err := ConfigureRootCAs(""); err != nil {
+			t.Fatalf("cleanup ConfigureRootCAs: %v", err)
+		}
 	})
 
 	if err := ConfigureRootCAs(certPath); err != nil {

--- a/internal/platform/netutil/netutil.go
+++ b/internal/platform/netutil/netutil.go
@@ -45,7 +45,7 @@ func NormalizeDomain(line string) string {
 		// preferimos Hostname(); si no, usamos Host (para conservar literal).
 		hostPort := parsed.Host
 		hostname := parsed.Hostname()
-		if hostname != "" && !(strings.Count(hostPort, ":") > 1 && !strings.Contains(hostPort, "[")) {
+		if hostname != "" && (strings.Count(hostPort, ":") <= 1 || strings.Contains(hostPort, "[")) {
 			candidate = hostname
 		} else if hostPort != "" {
 			candidate = hostPort

--- a/internal/platform/out/writer_test.go
+++ b/internal/platform/out/writer_test.go
@@ -88,7 +88,9 @@ func TestWriteDomain(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
-	defer w.Close()
+	defer func() {
+		_ = w.Close()
+	}()
 
 	inputs := []string{
 		"https://example.com",           // base
@@ -124,7 +126,9 @@ func TestWriteURL(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
-	defer w.Close()
+	defer func() {
+		_ = w.Close()
+	}()
 
 	inputs := []string{
 		"example.com/path",
@@ -157,7 +161,9 @@ func TestWriteRaw(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
-	defer w.Close()
+	defer func() {
+		_ = w.Close()
+	}()
 
 	inputs := []string{"line1", " line1 ", "line2"}
 	for _, in := range inputs {


### PR DESCRIPTION
## Summary
- add consistent cleanup and error handling for file and network resources across the pipeline and tests
- harden LinkFinderEVO sampling by switching to scoped random generators and surfacing IO errors while generating outputs
- tighten orchestrator and progress logging so step execution and UI writers surface unexpected failures

## Testing
- `golangci-lint run`
- `go test ./... -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68e6833222388329b11cf5ae3e3f819a